### PR TITLE
Add btag scale factor weights

### DIFF
--- a/hbt/config/analysis_hbt.py
+++ b/hbt/config/analysis_hbt.py
@@ -228,6 +228,9 @@ cfg.x.btag_working_points = DotDict.wrap({
     },
 })
 
+# name of the btag_sf correction set
+cfg.x.btag_sf_correction_set = "deepJet_shape"
+
 # name of the deep tau tagger
 # (used in the tec calibrator)
 cfg.x.tau_tagger = "DeepTau2017v2p1"
@@ -479,6 +482,10 @@ cfg.x.external_files = DotDict.wrap({
 
     # hh-btag repository (lightweight) with TF saved model directories
     "hh_btag_repo": ("https://github.com/hh-italian-group/HHbtag/archive/1dc426053418e1cab2aec021802faf31ddf3c5cd.tar.gz", "v1"),  # noqa
+
+    # btag scale factor
+    "btag_sf_corr": ("/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-d0a522ea/POG/BTV/2017_UL/btagging.json.gz", "v1"),
+
 })
 
 # target file size after MergeReducedEvents in MB

--- a/hbt/config/analysis_hbt.py
+++ b/hbt/config/analysis_hbt.py
@@ -539,7 +539,7 @@ cfg.x.external_files = DotDict.wrap({
     "hh_btag_repo": ("https://github.com/hh-italian-group/HHbtag/archive/1dc426053418e1cab2aec021802faf31ddf3c5cd.tar.gz", "v1"),  # noqa
 
     # btag scale factor
-    "btag_sf_corr": ("/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-d0a522ea/POG/BTV/2017_UL/btagging.json.gz", "v1"),
+    "btag_sf_corr": ("/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-d0a522ea/POG/BTV/2017_UL/btagging.json.gz", "v1"),  # noqa
 
 })
 

--- a/hbt/config/analysis_hbt.py
+++ b/hbt/config/analysis_hbt.py
@@ -554,8 +554,10 @@ cfg.x.keep_columns = DotDict.wrap({
         # object info
         "Jet.pt", "Jet.eta", "Jet.phi", "Jet.mass", "Jet.btagDeepFlavB", "Jet.hadronFlavour",
         "Jet.hhbtag",
-        "BJet.pt", "BJet.eta", "BJet.phi", "BJet.mass", "BJet.btagDeepFlavB", "BJet.hadronFlavour",
-        "BJet.hhbtag",
+        "HHBJet.pt", "HHBJet.eta", "HHBJet.phi", "HHBJet.mass", "HHBJet.btagDeepFlavB",
+        "HHBJet.hadronFlavour", "HHBJet.hhbtag",
+        "NonHHBJet.pt", "NonHHBJet.eta", "NonHHBJet.phi", "NonHHBJet.mass",
+        "NonHHBJet.btagDeepFlavB", "NonHHBJet.hadronFlavour", "NonHHBJet.hhbtag",
         "Electron.pt", "Electron.eta", "Electron.phi", "Electron.mass", "Electron.deltaEtaSC",
         "Electron.pfRelIso03_all",
         "Muon.pt", "Muon.eta", "Muon.phi", "Muon.mass", "Muon.pfRelIso04_all",
@@ -563,9 +565,10 @@ cfg.x.keep_columns = DotDict.wrap({
         "Tau.idDeepTau2017v2p1VSmu", "Tau.idDeepTau2017v2p1VSjet", "Tau.genPartFlav",
         "Tau.decayMode",
         "MET.pt", "MET.phi", "MET.significance", "MET.covXX", "MET.covXY", "MET.covYY",
+        "PV.npvs",
         # columns added during selection
-        "channel", "leptons_os", "tau2_isolated", "single_triggered", "cross_triggered",
-        "mc_weight", "PV.npvs", "category_ids", "deterministic_seed", "cutflow.*",
+        "channel", "process_id", "category_ids", "mc_weight", "leptons_os", "tau2_isolated",
+        "single_triggered", "cross_triggered", "deterministic_seed", "btag_weight*", "cutflow.*",
     },
     "cf.MergeSelectionMasks": {
         "mc_weight", "normalization_weight", "process_id", "category_ids", "cutflow.*",

--- a/hbt/config/analysis_hbt.py
+++ b/hbt/config/analysis_hbt.py
@@ -407,6 +407,7 @@ cfg.add_shift(name="cferr1_down", id=113, type="shape")
 cfg.add_shift(name="cferr2_up", id=114, type="shape")
 cfg.add_shift(name="cferr2_down", id=115, type="shape")
 
+
 def make_jme_filename(jme_aux, sample_type, name, era=None):
     """
     Convenience function to compute paths to JEC files.

--- a/hbt/config/analysis_hbt.py
+++ b/hbt/config/analysis_hbt.py
@@ -308,6 +308,48 @@ cfg.x.jec = DotDict.wrap({
     ],
 })
 
+# JEC uncertainty sources propagated to btag scale factors
+# (names derived from contents in BTV correctionlib file)
+cfg.x.btag_sf_jec_sources = [
+    "",  # total
+    "Absolute",
+    "AbsoluteMPFBias",
+    "AbsoluteScale",
+    "AbsoluteStat",
+    "Absolute_2017",
+    "BBEC1",
+    "BBEC1_2017",
+    "EC2",
+    "EC2_2017",
+    "FlavorQCD",
+    "Fragmentation",
+    "HF",
+    "HF_2017",
+    "PileUpDataMC",
+    "PileUpPtBB",
+    "PileUpPtEC1",
+    "PileUpPtEC2",
+    "PileUpPtHF",
+    "PileUpPtRef",
+    "RelativeBal",
+    "RelativeFSR",
+    "RelativeJEREC1",
+    "RelativeJEREC2",
+    "RelativeJERHF",
+    "RelativePtBB",
+    "RelativePtEC1",
+    "RelativePtEC2",
+    "RelativePtHF",
+    "RelativeSample",
+    "RelativeSample_2017",
+    "RelativeStatEC",
+    "RelativeStatFSR",
+    "RelativeStatHF",
+    "SinglePionECAL",
+    "SinglePionHCAL",
+    "TimePtEta",
+]
+
 cfg.x.jer = DotDict.wrap({
     "source": "https://raw.githubusercontent.com/cms-jet/JRDatabase/master/textFiles",
     "campaign": "Summer19UL17",
@@ -350,8 +392,20 @@ cfg.add_shift(name="top_pt_down", id=10, type="shape")
 add_aliases("top_pt", {"top_pt_weight": "top_pt_weight_{direction}"})
 for jec_source in cfg.x.jec["uncertainty_sources"]:
     idx = all_jec_sources.index(jec_source)
-    cfg.add_shift(name=f"jec_{jec_source}_up", id=5000 + 2 * idx, type="shape")
-    cfg.add_shift(name=f"jec_{jec_source}_down", id=5001 + 2 * idx, type="shape")
+    cfg.add_shift(
+        name=f"jec_{jec_source}_up",
+        id=5000 + 2 * idx,
+        type="shape",
+        tags={"jec"},
+        aux={"jec_source": jec_source},
+    )
+    cfg.add_shift(
+        name=f"jec_{jec_source}_down",
+        id=5001 + 2 * idx,
+        type="shape",
+        tags={"jec"},
+        aux={"jec_source": jec_source},
+    )
     add_aliases(
         f"jec_{jec_source}",
         {

--- a/hbt/config/variables.py
+++ b/hbt/config/variables.py
@@ -20,10 +20,10 @@ def add_variables(config: od.Config) -> None:
         x_title="Number of jets",
     )
     config.add_variable(
-        name="n_btag",
-        expression="n_btag",
-        binning=(11, -0.5, 10.5),
-        x_title="Number of b-tags",
+        name="n_hhbtag",
+        expression="n_hhbtag",
+        binning=(4, -0.5, 3.5),
+        x_title="Number of HH b-tags",
     )
     config.add_variable(
         name="mc_weight",

--- a/hbt/production/btag.py
+++ b/hbt/production/btag.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+
+"""
+btag corrections
+
+"""
+from columnflow.production import Producer, producer
+from columnflow.util import maybe_import
+from columnflow.columnar_util import set_ak_column
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+@producer(
+    uses={
+        "Jet.hadronFlavour", "Jet.eta", "Jet.pt", "Jet.btagDeepFlavB",
+    },
+    produces={
+        "btag_weight",
+    },
+)
+def btag_sf(
+    self: Producer,
+    events: ak.Array,
+    **kwargs,
+) -> ak.Array:
+    print("here")
+    from IPython import embed; embed()
+
+    return events
+
+
+@btag_sf.requires
+def btag_sf_requires(self: Producer, reqs: dict) -> None:
+    if "external_files" in reqs:
+        return
+
+    from columnflow.tasks.external import BundleExternalFiles
+    reqs["external_files"] = BundleExternalFiles.req(self.task)
+
+
+@btag_sf.setup
+def btag_sf_setup(self: Producer, reqs: dict, inputs: dict) -> None:
+    bundle = reqs["external_files"]
+
+    # create the btag sf corrector
+    import correctionlib
+    correction_set = correctionlib.CorrectionSet.from_string(
+        bundle.files.btag_sf_corr.load(formatter="gzip").decode("utf-8"),
+    )
+    self.btag_sf_corrector = correction_set[self.config_inst.x.btag_sf_correction_set]

--- a/hbt/production/btag.py
+++ b/hbt/production/btag.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-btag corrections
-
+Producers for btag scale factor weights.
 """
+
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column
@@ -25,7 +25,19 @@ def btag_sf(
     events: ak.Array,
     **kwargs,
 ) -> ak.Array:
-    print("here")
+    """
+    B-tag scale factor weight producer. Requires an external file in the config as (e.g.)
+
+    .. code-block:: python
+
+        "btag_sf_corr": ("/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-d0a522ea/POG/BTV/2017_UL/btagging.json.gz", "v1"),  # noqa
+
+    as well as an auxiliary entry in the config to refer to the b-tag correction set.
+
+    .. code-block:: python
+
+        cfg.x.btag_sf_correction_set = "deepJet_shape"
+    """
     from IPython import embed; embed()
 
     return events

--- a/hbt/production/btag.py
+++ b/hbt/production/btag.py
@@ -7,7 +7,7 @@ Producers for btag scale factor weights.
 from __future__ import annotations
 
 from columnflow.production import Producer, producer
-from columnflow.util import maybe_import
+from columnflow.util import maybe_import, safe_div
 from columnflow.columnar_util import set_ak_column, flat_np_view, layout_ak_array
 
 np = maybe_import("numpy")
@@ -47,6 +47,9 @@ def btag_weight(
        - https://twiki.cern.ch/twiki/bin/view/CMS/BTagShapeCalibration?rev=26
        - https://indico.cern.ch/event/1096988/contributions/4615134/attachments/2346047/4000529/Nov21_btaggingSFjsons.pdf
     """
+    if self.dataset_inst.is_data:
+        return events
+
     # get the total number of jets in the chunk
     n_jets_all = len(flat_np_view(events.Jet.pt, axis=1))
 
@@ -126,6 +129,12 @@ def btag_weight_init(self: Producer) -> None:
     #   2. when the nominal shift is requested, the central weight and all variations related to the
     #      method-intrinsic shifts are produced
     #   3. when any other shift is requested, only create the central weight column
+    if getattr(self, "dataset_inst", None) is None or self.dataset_inst.is_data:
+        self.jec_source = None
+        self.shift_is_known_jec_source = None
+        self.btag_uncs = None
+        return
+
     # to handle this efficiently in one spot, store jec information
     self.jec_source = self.shift_inst.x.jec_source if self.shift_inst.has_tag("jec") else None
     btag_sf_jec_source = "" if self.jec_source == "Total" else self.jec_source
@@ -165,7 +174,7 @@ def btag_weight_init(self: Producer) -> None:
 
 @btag_weight.requires
 def btag_weight_requires(self: Producer, reqs: dict) -> None:
-    if "external_files" in reqs:
+    if self.dataset_inst.is_data or "external_files" in reqs:
         return
 
     from columnflow.tasks.external import BundleExternalFiles
@@ -174,6 +183,9 @@ def btag_weight_requires(self: Producer, reqs: dict) -> None:
 
 @btag_weight.setup
 def btag_weight_setup(self: Producer, reqs: dict, inputs: dict) -> None:
+    if self.dataset_inst.is_data:
+        return
+
     bundle = reqs["external_files"]
 
     # create the btag sf corrector
@@ -182,3 +194,130 @@ def btag_weight_setup(self: Producer, reqs: dict, inputs: dict) -> None:
         bundle.files.btag_sf_corr.load(formatter="gzip").decode("utf-8"),
     )
     self.btag_sf_corrector = correction_set[self.config_inst.x.btag_sf_correction_set]
+
+
+@producer(
+    uses={
+        btag_weight.PRODUCES, "process_id", "Jet.pt",
+    },
+    # produced columns are defined in the init function below
+)
+def normalized_btag_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    if self.dataset_inst.is_data:
+        return events
+
+    for weight_name in self[btag_weight].produces:
+        if not weight_name.startswith("btag_weight"):
+            continue
+
+        # create a weight vectors starting with ones for both weight variations, i.e.,
+        # nomalization per pid and normalization per pid and jet multiplicity
+        norm_weight_per_pid = np.ones(len(events), dtype=np.float32)
+        norm_weight_per_pid_njet = np.ones(len(events), dtype=np.float32)
+
+        # fill weights with a new mask per unique process id (mostly just one)
+        for pid in self.unique_process_ids:
+            pid_mask = events.process_id == pid
+            # single value
+            norm_weight_per_pid[pid_mask] = self.ratio_per_pid[weight_name][pid]
+            # lookup table
+            n_jets = ak.num(events[pid_mask].Jet.pt, axis=1)
+            norm_weight_per_pid_njet[pid_mask] = self.ratio_per_pid_njet[weight_name][pid][n_jets]
+
+        # store them
+        events = set_ak_column(events, f"normalized_{weight_name}", norm_weight_per_pid)
+        events = set_ak_column(events, f"normalized_njet_{weight_name}", norm_weight_per_pid_njet)
+
+    return events
+
+
+@normalized_btag_weight.init
+def normalized_btag_weight_init(self: Producer) -> None:
+    if getattr(self, "dataset_inst", None) is None or self.dataset_inst.is_data:
+        return
+
+    # for btag weight, declare that one normalized version of the weight is produced
+    for weight_name in self[btag_weight].produces:
+        if not weight_name.startswith("btag_weight"):
+            continue
+
+        self.produces.add(f"normalized_{weight_name}")
+        self.produces.add(f"normalized_njet_{weight_name}")
+
+
+@normalized_btag_weight.requires
+def normalized_btag_weight_requires(self: Producer, reqs: dict) -> None:
+    # do nothing for data
+    if self.dataset_inst.is_data:
+        return
+
+    from columnflow.tasks.selection import MergeSelectionStats
+    reqs["selection_stats"] = MergeSelectionStats.req(
+        self.task,
+        tree_index=0,
+        branch=-1,
+        _exclude=MergeSelectionStats.exclude_params_forest_merge,
+    )
+
+
+@normalized_btag_weight.setup
+def normalized_btag_weight_setup(self: Producer, reqs: dict, inputs: dict) -> None:
+    # set to None for data
+    if self.dataset_inst.is_data:
+        self.unique_process_ids = None
+        self.ratio_per_pid = None
+        self.ratio_per_pid_njet = None
+        return
+
+    # load the selection stats
+    stats = inputs["selection_stats"]["collection"][0].load(formatter="json")
+
+    # get the unique process ids in that dataset
+    key = "sum_mc_weight_selected_no_bjet_per_process_and_njet"
+    self.unique_process_ids = list(map(int, stats[key].keys()))
+
+    # get the maximum numbers of jets
+    max_n_jets = max(map(int, sum((list(d.keys()) for d in stats[key].values()), [])))
+
+    # helper to get numerators and denominators
+    def numerator_per_pid(pid):
+        key = "sum_mc_weight_selected_no_bjet_per_process"
+        return stats[key].get(str(pid), 0.0)
+
+    def denominator_per_pid(weight_name, pid):
+        key = f"sum_mc_weight_{weight_name}_selected_no_bjet_per_process"
+        return stats[key].get(str(pid), 0.0)
+
+    def numerator_per_pid_njet(pid, n_jets):
+        key = "sum_mc_weight_selected_no_bjet_per_process_and_njet"
+        d = stats[key].get(str(pid), {})
+        return d.get(str(n_jets), 0.0)
+
+    def denominator_per_pid_njet(weight_name, pid, n_jets):
+        key = f"sum_mc_weight_{weight_name}_selected_no_bjet_per_process_and_njet"
+        d = stats[key].get(str(pid), {})
+        return d.get(str(n_jets), 0.0)
+
+    # extract the ratio per weight and pid
+    self.ratio_per_pid = {
+        weight_name: {
+            pid: safe_div(numerator_per_pid(pid), denominator_per_pid(weight_name, pid))
+            for pid in self.unique_process_ids
+        }
+        for weight_name in self[btag_weight].produces
+        if weight_name.startswith("btag_weight")
+    }
+
+    # extract the ratio per weight, pid and also the jet multiplicity, using the latter as in index
+    # for a lookup table (since it naturally starts at 0)
+    self.ratio_per_pid_njet = {
+        weight_name: {
+            pid: np.array([
+                safe_div(numerator_per_pid_njet(pid, n_jets), denominator_per_pid_njet(weight_name, pid, n_jets))
+                for n_jets in range(max_n_jets + 1)
+            ])
+            for pid in self.unique_process_ids
+        }
+        for weight_name in self[btag_weight].produces
+        if weight_name.startswith("btag_weight")
+    }

--- a/hbt/production/btag.py
+++ b/hbt/production/btag.py
@@ -6,7 +6,7 @@ Producers for btag scale factor weights.
 
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
-from columnflow.columnar_util import set_ak_column
+from columnflow.columnar_util import set_ak_column, flat_np_view, layout_ak_array
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -37,10 +37,101 @@ def btag_sf(
     .. code-block:: python
 
         cfg.x.btag_sf_correction_set = "deepJet_shape"
+
+    In addition, JEC uncertainty sources are propagated and weight columns are written if an
+    auxiliary config entry ``btag_sf_jec_sources`` exists.
+
+    Resources:
+
+       - https://twiki.cern.ch/twiki/bin/view/CMS/BTagShapeCalibration?rev=26
+       - https://indico.cern.ch/event/1096988/contributions/4615134/attachments/2346047/4000529/Nov21_btaggingSFjsons.pdf
     """
-    from IPython import embed; embed()
+    # get flat inputs
+    flavor = flat_np_view(events.Jet.hadronFlavour, axis=1)
+    abs_eta = flat_np_view(abs(events.Jet.eta), axis=1)
+    pt = flat_np_view(events.Jet.pt, axis=1)
+    b_discr = flat_np_view(events.Jet.btagDeepFlavB, axis=1)
+
+    # determine the position of c-flavored jets
+    c_mask = flavor == 4
+
+    # helper to create and store the weight
+    def add_weight(syst_name, syst_direction, column_name):
+        # start with flat ones and fill scale factors
+        sf_flat = np.ones_like(abs_eta)
+
+        # define an assignment mask
+        if syst_name in ["hf", "lf", "hfstats1", "hfstats2", "lfstats1", "lfstats2"]:
+            mask = ~c_mask
+        elif syst_name in ["cferr1", "cferr2"]:
+            mask = c_mask
+        else:
+            mask = Ellipsis
+
+        # get the flat scale factors
+        sf_flat[mask] = self.btag_sf_corrector.evaluate(
+            syst_name if syst_name == "central" else f"{syst_direction}_{syst_name}",
+            flavor[mask],
+            abs_eta[mask],
+            pt[mask],
+            b_discr[mask],
+        )
+
+        # enforce the correct shape and create the product via all jets per event
+        sf = layout_ak_array(sf_flat.astype(np.float32), events.Jet.pt)
+        weight = ak.prod(sf, axis=1, mask_identity=False)
+
+        # save the new column
+        return set_ak_column(events, column_name, weight)
+
+    # when the uncertainty is a known jec shift, obtain the propagated effect and do not produce
+    # additional systematics
+    jec_source = self.shift_inst.x.jec_source if self.shift_inst.has_tag("jec") else None
+    btag_sf_jec_source = "" if jec_source == "Total" else jec_source
+    if jec_source and btag_sf_jec_source in self.config_inst.x("btag_sf_jec_sources", []):
+        # TODO: year dependent jec variations covered?
+        events = add_weight(
+            f"jes{'' if jec_source == 'Total' else jec_source}",
+            self.shift_inst.direction,
+            f"btag_weight_jec_{jec_source}_{self.shift_inst.direction}",
+        )
+    elif self.shift_inst.is_nominal:
+        # nominal weight and those of all method intrinsic uncertainties
+        events = add_weight("central", None, "btag_weight")
+        for syst_name, col_name in self.btag_uncs.items():
+            for direction in ["up", "down"]:
+                name = col_name.format(year=self.config_inst.campaign.x.year)
+                events = add_weight(
+                    syst_name,
+                    direction,
+                    f"btag_weight_{name}_{direction}",
+                )
+    else:
+        # any other shift, just produce the nominal weight
+        events = add_weight("central", None, "btag_weight")
 
     return events
+
+
+@btag_sf.init
+def btag_sf_init(self: Producer) -> None:
+    # save names of method-intrinsic uncertainties
+    self.btag_uncs = {
+        "hf": "hf",
+        "lf": "lf",
+        "hfstats1": "hfstats1_{year}",
+        "hfstats2": "hfstats2_{year}",
+        "lfstats1": "lfstats1_{year}",
+        "lfstats2": "lfstats2_{year}",
+        "cferr1": "cferr1",
+        "cferr2": "cferr2",
+    }
+
+    # add uncertainty sources of the method itself
+    for col_name in self.btag_uncs.values():
+        for direction in ["up", "down"]:
+            name = col_name.format(year=self.config_inst.campaign.x.year)
+            self.produces.add(f"btag_weight_{name}_{direction}")
 
 
 @btag_sf.requires

--- a/hbt/production/btag.py
+++ b/hbt/production/btag.py
@@ -184,6 +184,7 @@ def btag_weight_requires(self: Producer, reqs: dict) -> None:
 @btag_weight.setup
 def btag_weight_setup(self: Producer, reqs: dict, inputs: dict) -> None:
     if self.dataset_inst.is_data:
+        self.btag_sf_corrector = None
         return
 
     bundle = reqs["external_files"]

--- a/hbt/production/features.py
+++ b/hbt/production/features.py
@@ -38,7 +38,7 @@ def jet_energy_shifts_init(self: Producer) -> None:
         "Electron.pt", "Muon.pt", "Jet.pt", "BJet.pt",
     },
     produces={
-        "ht", "n_jet", "n_btag", "n_electron", "n_muon",
+        "ht", "n_jet", "n_hhbtag", "n_electron", "n_muon",
     },
     shifts={
         jet_energy_shifts,
@@ -47,7 +47,7 @@ def jet_energy_shifts_init(self: Producer) -> None:
 def features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     events = set_ak_column(events, "ht", ak.sum(events.Jet.pt, axis=1))
     events = set_ak_column(events, "n_jet", ak.num(events.Jet.pt, axis=1))
-    events = set_ak_column(events, "n_btag", ak.num(events.BJet.pt, axis=1))
+    events = set_ak_column(events, "n_hhbtag", ak.num(events.HHBJet.pt, axis=1))
     events = set_ak_column(events, "n_electron", ak.num(events.Electron.pt, axis=1))
     events = set_ak_column(events, "n_muon", ak.num(events.Muon.pt, axis=1))
 

--- a/hbt/selection/jet.py
+++ b/hbt/selection/jet.py
@@ -201,9 +201,9 @@ def jet_selection(
             },
         },
         aux={
-            "n_central_jets": (
-                ak.num(jet_indices, axis=1) +
-                ak.num(bjet_indices, axis=1)
-            ),
+            # jet mask that lead to the jet_indices
+            "jet_mask": default_mask,
+            # used to determine sum of weights in increment_stats
+            "n_central_jets": ak.num(jet_indices, axis=1),
         },
     )

--- a/hbt/selection/jet.py
+++ b/hbt/selection/jet.py
@@ -69,9 +69,9 @@ def jet_selection(
     # get the scores of the hhbtag and per event get the two indices corresponding to the best pick
     hhbtag_scores = self[hhbtag](events, default_mask, lepton_results.x.lepton_pair, **kwargs)
     score_indices = ak.argsort(hhbtag_scores, axis=1, ascending=False)
-    # pad the indices to simplify creating the bjet mask
-    padded_bjet_indices = ak.pad_none(score_indices, 2, axis=1)[..., :2][..., :2]
-    bjet_mask = ((li == padded_bjet_indices[..., [0]]) | (li == padded_bjet_indices[..., [1]]))
+    # pad the indices to simplify creating the hhbjet mask
+    padded_hhbjet_indices = ak.pad_none(score_indices, 2, axis=1)[..., :2][..., :2]
+    hhbjet_mask = ((li == padded_hhbjet_indices[..., [0]]) | (li == padded_hhbjet_indices[..., [1]]))
     # get indices for actual book keeping only for events with both lepton candidates and where at
     # least two jets pass the default mask (bjet candidates)
     valid_score_mask = (
@@ -79,14 +79,14 @@ def jet_selection(
         (ak.sum(default_mask, axis=1) >= 2) &
         (ak.num(lepton_results.x.lepton_pair, axis=1) == 2)
     )
-    bjet_indices = score_indices[valid_score_mask[score_indices]][..., :2]
+    hhbjet_indices = score_indices[valid_score_mask[score_indices]][..., :2]
 
     # vbf jets
     vbf_mask = (
         ak4_mask &
         (events.Jet.pt > 30.0) &
         (abs(events.Jet.eta) < 4.7) &
-        (~bjet_mask)
+        (~hhbjet_mask)
     )
 
     # build vectors of vbf jets representing all combinations and apply selections
@@ -140,10 +140,10 @@ def jet_selection(
     )
 
     # unique subjet matching
-    metrics = events.FatJet.subjets.metric_table(events.Jet[bjet_indices])
+    metrics = events.FatJet.subjets.metric_table(events.Jet[hhbjet_indices])
     subjets_match = (
         ak.all(ak.sum(metrics < 0.4, axis=3) == 1, axis=2) &
-        (ak.num(bjet_indices, axis=1) == 2)
+        (ak.num(hhbjet_indices, axis=1) == 2)
     )
     fatjet_mask = fatjet_mask & subjets_match
 
@@ -162,23 +162,24 @@ def jet_selection(
     wp = self.config_inst.x.btag_working_points.deepcsv.loose
     subjets_btagged = ak.all(events.SubJet[ak.firsts(subjet_indices)].btagDeepB > wp, axis=1)
 
-    # for central jets ("bjetcandidates") remove bjets to avoid amiguities later on
-    # note: disabled for the moment, meaning that all bjets are contained in jets
-    # default_mask = default_mask & (~bjet_mask)
-
     # pt sorted indices to convert mask
     sorted_indices = ak.argsort(events.Jet.pt, axis=-1, ascending=False)
     jet_indices = sorted_indices[default_mask[sorted_indices]]
 
+    # keep indices of default jets that are explicitly not selected as hhbjets for easier handling
+    non_hhbjet_mask = default_mask & (~hhbjet_mask)
+    non_hhbjet_indices = sorted_indices[non_hhbjet_mask[sorted_indices]]
+
     # final event selection
     jet_sel = (
         (ak.sum(default_mask, axis=1) >= 2) &
-        ak.fill_none(subjets_btagged, True)  # was none for events with not matched fatjet
+        ak.fill_none(subjets_btagged, True)  # was none for events with no matched fatjet
     )
 
     # some final type conversions
     jet_indices = ak.values_astype(ak.fill_none(jet_indices, 0), np.int32)
-    bjet_indices = ak.values_astype(bjet_indices, np.int32)
+    hhbjet_indices = ak.values_astype(hhbjet_indices, np.int32)
+    non_hhbjet_indices = ak.values_astype(ak.fill_none(non_hhbjet_indices, 0), np.int32)
     fatjet_indices = ak.values_astype(fatjet_indices, np.int32)
     vbfjet_indices = ak.values_astype(ak.fill_none(vbfjet_indices, 0), np.int32)
 
@@ -189,11 +190,16 @@ def jet_selection(
     return events, SelectionResult(
         steps={
             "jet": jet_sel,
+            # the btag weight normalization requires a selection with everything but the bjet
+            # selection, so add this step here
+            # note: there is currently no b-tag discriminant cut at this point, so take jet_sel
+            "bjet": jet_sel,
         },
         objects={
             "Jet": {
                 "Jet": jet_indices,
-                "BJet": bjet_indices,
+                "HHBJet": hhbjet_indices,
+                "NonHHBJet": non_hhbjet_indices,
                 "FatJet": fatjet_indices,
                 "SubJet1": subjet_indices[..., 0],
                 "SubJet2": subjet_indices[..., 1],

--- a/law.cfg
+++ b/law.cfg
@@ -28,6 +28,9 @@ selection_modules: hbt.selection.{default,lepton,trigger,jetmet,categories}
 ml_modules: hbt.ml.test
 inference_modules: hbt.inference.test
 
+# wether or not the ensure_proxy decorator should be skipped, even if used by task's run methods
+skip_ensure_proxy: False
+
 
 [outputs]
 

--- a/law.cfg
+++ b/law.cfg
@@ -52,7 +52,9 @@ cf.BundleExternalFiles: wlcg
 cf.GetDatasetLFNs: wlcg
 cf.CalibrateEvents: wlcg
 cf.SelectEvents: wlcg
+cf.MergeSelectionStats: wlcg
 cf.ReduceEvents: wlcg
+cf.MergeReductionStats: wlcg
 cf.MergeReducedEvents: wlcg
 cf.ProduceColumns: wlcg
 cf.PrepareMLEvents: wlcg

--- a/law.cfg
+++ b/law.cfg
@@ -22,7 +22,7 @@ default_analysis: hbt.config.analysis_hbt.analysis_hbt
 default_config: run2_2017_nano_v9
 default_dataset: hh_ggf_bbtautau_madgraph
 
-production_modules: columnflow.production.{categories,processes,pileup,normalization,seeds,mc_weight,electron}, hbt.production.{default,weights,features,tau}
+production_modules: columnflow.production.{categories,processes,pileup,normalization,seeds,mc_weight,electron}, hbt.production.{weights,features,tau,btag}
 calibration_modules: columnflow.calibration.{jets,met}, hbt.calibration.{default,jet,tau}
 selection_modules: hbt.selection.{default,lepton,trigger,jetmet,categories}
 ml_modules: hbt.ml.test

--- a/law.cfg
+++ b/law.cfg
@@ -22,7 +22,7 @@ default_analysis: hbt.config.analysis_hbt.analysis_hbt
 default_config: run2_2017_nano_v9
 default_dataset: hh_ggf_bbtautau_madgraph
 
-production_modules: columnflow.production.{categories,processes,pileup,normalization,seeds,mc_weight,electron}, hbt.production.{weights,features,tau,btag}
+production_modules: columnflow.production.{categories,processes,pileup,normalization,seeds,mc_weight,electron}, hbt.production.{default,weights,features,tau,btag}
 calibration_modules: columnflow.calibration.{jets,met}, hbt.calibration.{default,jet,tau}
 selection_modules: hbt.selection.{default,lepton,trigger,jetmet,categories}
 ml_modules: hbt.ml.test

--- a/law.cfg
+++ b/law.cfg
@@ -57,6 +57,7 @@ cf.ReduceEvents: wlcg
 cf.MergeReductionStats: wlcg
 cf.MergeReducedEvents: wlcg
 cf.ProduceColumns: wlcg
+cf.CreatePileupWeights: wlcg
 cf.PrepareMLEvents: wlcg
 cf.MergeMLEvents: wlcg
 cf.MLTraining: wlcg

--- a/tests/run_all
+++ b/tests/run_all
@@ -8,7 +8,7 @@
 #      previous scripts.
 
 action() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
 
@@ -21,23 +21,23 @@ action() {
 
     # colored echo helper
     cecho() {
-        local col="$1"
-        local msg="$2"
+        local col="${1}"
+        local msg="${2}"
         echo -e "\x1b[0;49;${col}m${msg}\x1b[0m"
     }
 
     # linting
     cecho 35 "check linting ..."
-    bash "$this_dir/run_linting"
+    bash "${this_dir}/run_linting"
     ret="$?"
-    if [ "$ret" != "0" ]; then
-        2>&1 cecho 31 "run_linting failed with exit code $ret"
-        [ "$mode" = "force" ] || return "$ret"
+    if [ "${ret}" != "0" ]; then
+        2>&1 cecho 31 "run_linting failed with exit code ${ret}"
+        [ "${mode}" = "force" ] || return "${ret}"
         ret_global="1"
     else
         cecho 32 "done"
     fi
 
-    return "$ret_global"
+    return "${ret_global}"
 }
 action "$@"

--- a/tests/run_linting
+++ b/tests/run_linting
@@ -3,7 +3,7 @@
 # Script that runs linting checks on selected files.
 
 action() {
-    local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
     local hbt_dir="$( dirname "$this_dir" )"


### PR DESCRIPTION
This PR adds a first draft for a producer that creates btag scale factor weights, based on the correctionlib.

The complexity of this PR is driven by the fact that predicted event rates should not change if the btag weights are applied and thus preserving sum of event weights before any btag cut is applied. This requires measuring the sum of `weight_mc x weight_btag` values beforehand, and then renormalizing the event weights after the selection.

There are multiple ways in which these renormalization factors can be extracted. This PR focuses on two of them:

- Per process id
- Per process id and jet multiplicity.

The latter might be preferred but this is up to the analysis to decide at a later stage.