### PR TITLE
correct JEC and JER config entries for 2016

### DIFF
--- a/hbt/config/configs_run2ul.py
+++ b/hbt/config/configs_run2ul.py
@@ -253,7 +253,7 @@ def add_config(
 
     # jec configuration
     # https://twiki.cern.ch/twiki/bin/view/CMS/JECDataMC?rev=201
-    jerc_postfix = "APV" if year == 2016 and campaign.x.vfp == "post" else ""
+    jerc_postfix = "APV" if year == 2016 and campaign.x.vfp == "pre" else ""
     cfg.x.jec = DotDict.wrap({
         "campaign": f"Summer19UL{year2}{jerc_postfix}",
         "version": {2016: "V7", 2017: "V5", 2018: "V5"}[year],
@@ -323,7 +323,7 @@ def add_config(
     # JER
     # https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution?rev=107
     cfg.x.jer = DotDict.wrap({
-        "campaign": f"Summer19UL{year2}{jerc_postfix}",
+        "campaign": {2016: "Summer20", 2017: "Summer19", 2018: "Summer19"}[year] + f"UL{year2}{jerc_postfix}",
         "version": "JR" + {2016: "V3", 2017: "V2", 2018: "V2"}[year],
         "jet_type": "AK4PFchs",
     })

--- a/hbt/config/configs_run2ul.py
+++ b/hbt/config/configs_run2ul.py
@@ -322,8 +322,9 @@ def add_config(
 
     # JER
     # https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution?rev=107
+    jer_year = "20" if year == 2016 else "19"
     cfg.x.jer = DotDict.wrap({
-        "campaign": {2016: "Summer20", 2017: "Summer19", 2018: "Summer19"}[year] + f"UL{year2}{jerc_postfix}",
+        "campaign": f"Summer{jer_year}UL{year2}{jerc_postfix}",
         "version": "JR" + {2016: "V3", 2017: "V2", 2018: "V2"}[year],
         "jet_type": "AK4PFchs",
     })


### PR DESCRIPTION
correct the config entries for JER corresponding to the twiki given as source (for 2016, the corrections are Summer20 and not Summer19) and correct the JEC entry as is seen in the gz file from the jsonpog-integration repository (the "APV" postscript comes only for corrections in the "preVFP" directory)