### PR TITLE
Merging 2016 run (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ data
 .setups
 .mypy_cache
 .vscode
+.python-version

--- a/hbt/calibration/default.py
+++ b/hbt/calibration/default.py
@@ -10,12 +10,11 @@ from columnflow.calibration.cms.jets import jec, jer
 from columnflow.production.cms.mc_weight import mc_weight
 from columnflow.production.cms.seeds import deterministic_seeds
 from columnflow.util import maybe_import
-
 from hbt.calibration.tau import tec
 
 
 ak = maybe_import("awkward")
-
+np = maybe_import("numpy")
 
 # derive calibrators to add settings
 jec_nominal = jec.derive("jec_nominal", cls_dict={"uncertainty_sources": [], "data_only": True})
@@ -47,4 +46,12 @@ def default(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     if self.dataset_inst.is_mc:
         events = self[tec](events, **kwargs)
 
+    return events
+
+
+@calibrator(
+    uses=set(),
+    produces=set(),
+)
+def empty(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     return events

--- a/hbt/calibration/placeholder.py
+++ b/hbt/calibration/placeholder.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+
+"""
+Placeholder calibrator to produce missing single trigger columns.
+Does not include default calibrations.
+"""
+
+from columnflow.calibration import Calibrator, calibrator
+from columnflow.util import maybe_import
+from columnflow.columnar_util import set_ak_column
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+@calibrator(
+    uses={
+        "Electron.pt", "Electron.eta", "Muon.pt", "Muon.eta", "Tau.pt",
+    },
+    produces={
+        "HLT_Ele25_eta2p1_WPTight_Gsf", "HLT_IsoMu22", "HLT_IsoMu22_eta2p1", "HLT_IsoTkMu22", "HLT_IsoTkMu22_eta2p1",
+        "HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau30", "HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20",
+        "HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1",
+    },
+)
+def placeholder(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
+
+    HLT_Ele25_eta2p1_WPTight_Gsf = ak.any(
+        (events.Electron.pt >= 25.5) &
+        (events.Electron.eta <= 2.1),
+        axis=1,
+    )
+
+    HLT_IsoMu22 = ak.any(
+        (events.Muon.pt >= 22.5),
+        axis=1,
+    )
+
+    HLT_IsoMu22_eta2p1 = ak.any(
+        (events.Muon.pt >= 22.5) &
+        (events.Muon.eta <= 2.1),
+        axis=1,
+    )
+
+    HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau30 = (
+        ak.any(
+            (events.Electron.pt >= 24.5) &
+            (events.Electron.eta <= 2.1),
+            axis=1,
+        ) & ak.any(
+            (events.Tau.pt >= 30.5),
+            axis=1,
+        )
+    )
+
+    HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20 = (
+        ak.any(
+            (events.Electron.pt >= 24.5) &
+            (events.Electron.eta <= 2.1),
+            axis=1,
+        ) & ak.any(
+            (events.Tau.pt >= 20.5),
+            axis=1,
+        )
+    )
+
+    HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1 = (
+        ak.any(
+            (events.Electron.pt >= 24.5) &
+            (events.Electron.eta <= 2.1),
+            axis=1,
+        ) & ak.any(
+            (events.Tau.pt >= 20.5),
+            axis=1,
+        )
+    )
+
+    events = set_ak_column(events, "HLT_Ele25_eta2p1_WPTight_Gsf", HLT_Ele25_eta2p1_WPTight_Gsf)
+    events = set_ak_column(events, "HLT_IsoMu22", HLT_IsoMu22)
+    events = set_ak_column(events, "HLT_IsoMu22_eta2p1", HLT_IsoMu22_eta2p1)
+    events = set_ak_column(events, "HLT_IsoTkMu22", HLT_IsoMu22)
+    events = set_ak_column(events, "HLT_IsoTkMu22_eta2p1", HLT_IsoMu22_eta2p1)
+    events = set_ak_column(
+        events,
+        "HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau30",
+        HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau30,
+    )
+    events = set_ak_column(
+        events,
+        "HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20",
+        HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20,
+    )
+    events = set_ak_column(
+        events,
+        "HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1",
+        HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1,
+    )
+
+    return events

--- a/hbt/config/analysis_hbt.py
+++ b/hbt/config/analysis_hbt.py
@@ -42,11 +42,51 @@ analysis_hbt.x.config_groups = {}
 # load configs
 #
 
-# 2017
 from hbt.config.configs_run2ul import add_config as add_config_run2ul
+
+# 2016 HIPM
+from cmsdb.campaigns.run2_2016_HIPM_nano_uhh_v12 import campaign_run2_2016_HIPM_nano_uhh_v12
+
+# default v12 config
+add_config_run2ul(
+    analysis_hbt,
+    campaign_run2_2016_HIPM_nano_uhh_v12.copy(),
+    config_name=campaign_run2_2016_HIPM_nano_uhh_v12.name,
+    config_id=6,  # random number here that is not repeated ?
+)
+
+# default v12 config with limited number of files for faster prototyping
+add_config_run2ul(
+    analysis_hbt,
+    campaign_run2_2016_HIPM_nano_uhh_v12.copy(),
+    config_name=f"{campaign_run2_2016_HIPM_nano_uhh_v12.name}_limited",
+    config_id=16,  # random number here that is not repeated ?
+    limit_dataset_files=2,
+)
+
+# 2016 post
+from cmsdb.campaigns.run2_2016_nano_uhh_v12 import campaign_run2_2016_nano_uhh_v12
+
+# v12 uhh config with full datasets
+add_config_run2ul(
+    analysis_hbt,
+    campaign_run2_2016_nano_uhh_v12.copy(),
+    config_name=campaign_run2_2016_nano_uhh_v12.name,
+    config_id=3,
+)
+
+# v12 uhh config with limited number of files for faster prototyping
+add_config_run2ul(
+    analysis_hbt,
+    campaign_run2_2016_nano_uhh_v12.copy(),
+    config_name=f"{campaign_run2_2016_nano_uhh_v12.name}_limited",
+    config_id=13,
+    limit_dataset_files=2,
+)
+
+# 2017
 from cmsdb.campaigns.run2_2017_nano_v9 import campaign_run2_2017_nano_v9
 from cmsdb.campaigns.run2_2017_nano_uhh_v11 import campaign_run2_2017_nano_uhh_v11
-
 
 # default v9 config
 add_config_run2ul(

--- a/hbt/config/triggers.py
+++ b/hbt/config/triggers.py
@@ -8,6 +8,273 @@ import order as od
 
 from hbt.config.util import Trigger, TriggerLeg
 
+# 2016 triggers as per AN of CMS-HIG-20-010 (AN2018_121_v11-1)
+
+
+def add_triggers_2016(config: od.Config, era: str) -> None:
+    """
+    Adds all triggers to a *config*. For the conversion from filter names to trigger bits, see
+    https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/triggerObjects_cff.py.
+    """
+    config.x.triggers = od.UniqueObjectIndex(Trigger, [
+        #
+        # e tauh (NO Triggers in AN)
+        # used the triggers from https://twiki.cern.ch/twiki/bin/view/CMS/TauTrigger#Tau_Triggers_in_NanoAOD_2016
+        Trigger(
+            name="HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1",
+            id=710,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=11,
+                    min_pt=26.0,  # TODO
+                    # filter names:
+                    #
+                    trigger_bits=None,  # TODO
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=22.0,  # TODO
+                    # filter names:
+                    #
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            applies_to_dataset=(
+                lambda dataset_inst: dataset_inst.is_mc or (dataset_inst.x.era <= "E")  # TODO: to be checked!
+                # does not exist for run F on but should only be used until run 276215 -> which era?
+            ),
+            tags={"cross_trigger", "cross_e_tau", "channel_e_tau"},
+        ),
+        Trigger(
+            name="HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20",
+            id=711,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=11,
+                    min_pt=26.0,  # TODO
+                    # filter names:
+                    #
+                    trigger_bits=None,  # TODO
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=22.0,  # TODO
+                    # filter names:
+                    #
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            applies_to_dataset=(
+                lambda dataset_inst: dataset_inst.is_data and dataset_inst.x.era <= "E"  # TODO: to be checked!
+                # does not exist for run F on but should only be used between run 276215 and 278270 -> which eras?
+            ),
+            tags={"cross_trigger", "cross_e_tau", "channel_e_tau"},
+        ),
+        Trigger(
+            name="HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau30",
+            id=712,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=11,
+                    min_pt=26.0,  # TODO
+                    # filter names:
+                    #
+                    trigger_bits=None,  # TODO
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=32.0,  # TODO
+                    # filter names:
+                    #
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            applies_to_dataset=(
+                lambda dataset_inst: dataset_inst.is_data and dataset_inst.x.era >= "E"  # TODO: to be checked!
+                # does not exist until run E but should only be used after run 278270 -> which era?
+            ),
+            tags={"cross_trigger", "cross_e_tau", "channel_e_tau"},
+        ),
+
+        #
+        # mu tauh
+        #
+        Trigger(
+            name="HLT_IsoMu19_eta2p1_LooseIsoPFTau20",
+            id=706,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=13,
+                    min_pt=22,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=23,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            tags={"cross_trigger", "cross_mu_tau", "channel_mu_tau"},
+        ),
+        Trigger(
+            name="HLT_IsoMu19_eta2p1_LooseIsoPFTau20_SingleL1",
+            id=707,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=13,
+                    min_pt=22,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=23,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            tags={"cross_trigger", "cross_mu_tau", "channel_mu_tau"},
+        ),
+
+        #
+        # tauh tauh
+        #
+        Trigger(
+            name="HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg",
+            id=708,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=38,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=38,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc or
+                (dataset_inst.x.era >= "B" and dataset_inst.x.era <= "F")
+            ),
+            tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
+        ),
+        Trigger(
+            name="HLT_DoubleMediumCombinedIsoPFTau35_Trk1_eta2p1_Reg",
+            id=709,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=38,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=38,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc or dataset_inst.x.era >= "H"),
+            tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
+        ),
+
+        #
+        # vbf  (NO Triggers)
+        #
+    ])
+
+    if era == "pre":
+        #
+        # single electron
+        #
+        config.x.triggers.add(
+            name="HLT_Ele25_eta2p1_WPTight_Gsf",
+            id=701,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=11,
+                    min_pt=28,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            tags={"single_trigger", "single_e", "channel_e_tau"},
+        )
+        #
+        # single muon
+        #
+        config.x.triggers.add(
+            name="HLT_IsoMu22",
+            id=702,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=13,
+                    min_pt=25,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            tags={"single_trigger", "single_mu", "channel_mu_tau"},
+        )
+        config.x.triggers.add(
+            name="HLT_IsoMu22_eta2p1",
+            id=703,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=13,
+                    min_pt=25,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            tags={"single_trigger", "single_mu", "channel_mu_tau"},
+        )
+        config.x.triggers.add(
+            name="HLT_IsoTkMu22",
+            id=704,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=13,
+                    min_pt=25,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            tags={"single_trigger", "single_mu", "channel_mu_tau"},
+        )
+        config.x.triggers.add(
+            name="HLT_IsoTkMu22_eta2p1",
+            id=705,  # TODO
+            legs=[
+                TriggerLeg(
+                    pdg_id=13,
+                    min_pt=25,  # TODO
+                    # filter names:
+                    # TODO
+                    trigger_bits=None,  # TODO
+                ),
+            ],
+            tags={"single_trigger", "single_mu", "channel_mu_tau"},
+        )
+
 
 def add_triggers_2017(config: od.Config) -> None:
     """
@@ -173,6 +440,242 @@ def add_triggers_2017(config: od.Config) -> None:
             ],
             tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
         ),
+        Trigger(
+            name="HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg",
+            id=502,
+            legs=[
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=40.0,
+                    # filter names:
+                    # hltDoublePFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsDz02Reg
+                    trigger_bits=64,
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=40.0,
+                    # filter names:
+                    # hltDoublePFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsDz02Reg
+                    trigger_bits=64,
+                ),
+            ],
+            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data),
+            tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
+        ),
+        Trigger(
+            name="HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg",
+            id=503,
+            legs=[
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=45.0,
+                    # filter names:
+                    # hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg
+                    trigger_bits=64,
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=45.0,
+                    # filter names:
+                    # hltDoublePFTau40TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg
+                    trigger_bits=64,
+                ),
+            ],
+            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data),
+            tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
+        ),
+        Trigger(
+            name="HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg",
+            id=504,
+            legs=[
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=45.0,
+                    # filter names:
+                    # hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg
+                    trigger_bits=64,
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=45.0,
+                    # filter names:
+                    # hltDoublePFTau40TrackPt1TightChargedIsolationDz02Reg
+                    trigger_bits=64,
+                ),
+            ],
+            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data),
+            tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
+        ),
+
+        #
+        # vbf
+        #
+        Trigger(
+            name="HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg",
+            id=601,
+            legs=[
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=25.0,
+                    # filter names:
+                    # hltDoublePFTau20TrackPt1LooseChargedIsolation
+                    trigger_bits=2048,
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=25.0,
+                    # filter names:
+                    # hltDoublePFTau20TrackPt1LooseChargedIsolation
+                    trigger_bits=2048,
+                ),
+                # additional leg infos for vbf jets
+                TriggerLeg(
+                    min_pt=115.0,
+                    # filter names:
+                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20
+                    trigger_bits=1,
+                ),
+                TriggerLeg(
+                    min_pt=40.0,
+                    # filter names:
+                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleLooseChargedIsoPFTau20
+                    trigger_bits=1,
+                ),
+            ],
+            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc or dataset_inst.x.era >= "D"),
+            tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
+        ),
+    ])
+
+
+def add_triggers_2018(config: od.Config) -> None:
+    config.x.triggers = od.UniqueObjectIndex(Trigger, [
+        #
+        # single electron
+        #
+        Trigger(
+            name="HLT_Ele32_WPTight_Gsf",
+            id=201,
+            legs=[
+                TriggerLeg(
+                    pdg_id=11,
+                    min_pt=35.0,
+                    # filter names:
+                    # hltEle32WPTightGsfTrackIsoFilter
+                    trigger_bits=2,
+                ),
+            ],
+            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc or dataset_inst.x.era >= "D"),
+            tags={"single_trigger", "single_e", "channel_e_tau"},
+        ),
+        Trigger(
+            name="HLT_Ele35_WPTight_Gsf",
+            id=203,
+            legs=[
+                TriggerLeg(
+                    pdg_id=11,
+                    min_pt=38.0,
+                    # filter names:
+                    # hltEle35noerWPTightGsfTrackIsoFilter
+                    trigger_bits=2,
+                ),
+            ],
+            tags={"single_trigger", "single_e", "channel_e_tau"},
+        ),
+
+        #
+        # single muon
+        #
+        Trigger(
+            name="HLT_IsoMu24",
+            id=101,
+            legs=[
+                TriggerLeg(
+                    pdg_id=13,
+                    min_pt=26.0,
+                    # filter names:
+                    # hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07
+                    trigger_bits=2,
+                ),
+            ],
+            tags={"single_trigger", "single_mu", "channel_mu_tau"},
+        ),
+        Trigger(
+            name="HLT_IsoMu27",
+            id=102,
+            legs=[
+                TriggerLeg(
+                    pdg_id=13,
+                    min_pt=29.0,
+                    # filter names:
+                    # hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07
+                    trigger_bits=2,
+                ),
+            ],
+            tags={"single_trigger", "single_mu", "channel_mu_tau"},
+        ),
+
+        #
+        # e tauh
+        #
+        Trigger(
+            name="HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1",
+            id=401,
+            legs=[
+                TriggerLeg(
+                    pdg_id=11,
+                    min_pt=27.0,
+                    # filter names:
+                    # hltEle24erWPTightGsfTrackIsoFilterForTau
+                    # hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30
+                    trigger_bits=2 + 64,
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=35.0,
+                    # filter names:
+                    # hltSelectedPFTau30LooseChargedIsolationL1HLTMatched
+                    # hltOverlapFilterIsoEle24WPTightGsfLooseIsoPFTau30
+                    trigger_bits=1024 + 256,
+                ),
+            ],
+            # the non-HPS path existed only for data and is fully covered in MC below
+            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data),
+            tags={"cross_trigger", "cross_e_tau", "channel_e_tau"},
+        ),
+
+        #
+        # mu tauh
+        #
+        Trigger(
+            name="HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1",
+            id=301,
+            legs=[
+                TriggerLeg(
+                    pdg_id=13,
+                    min_pt=22.0,
+                    # filter names:
+                    # hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07
+                    # hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded
+                    trigger_bits=2 + 64,
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=32.0,
+                    # filter names:
+                    # hltSelectedPFTau27LooseChargedIsolationAgainstMuonL1HLTMatched or
+                    # hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded
+                    trigger_bits=1024 + 512,
+                ),
+            ],
+            # the non-HPS path existed only for data and is fully covered in MC below
+            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data),
+            tags={"cross_trigger", "cross_mu_tau", "channel_mu_tau"},
+        ),
+
+        #
+        # tauh tauh
+        #
         Trigger(
             name="HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg",
             id=502,

--- a/hbt/config/variables.py
+++ b/hbt/config/variables.py
@@ -55,6 +55,14 @@ def add_variables(config: od.Config) -> None:
         x_title="HT",
     )
     config.add_variable(
+        name="jet_pt",
+        expression="Jet.pt",
+        null_value=EMPTY_FLOAT,
+        binning=(40, 0.0, 400.0),
+        unit="GeV",
+        x_title=r"all Jet $p_{T}$",
+    )
+    config.add_variable(
         name="jet1_pt",
         expression="Jet.pt[:,0]",
         null_value=EMPTY_FLOAT,
@@ -83,6 +91,14 @@ def add_variables(config: od.Config) -> None:
         null_value=EMPTY_FLOAT,
         binning=(33, -3.3, 3.3),
         x_title=r"MET $\phi$",
+    )
+
+    config.add_variable(
+        name="e_pt",
+        expression="Electron.pt",
+        null_value=EMPTY_FLOAT,
+        binning=(400, 0, 400),
+        x_title=r"Electron p$_{T}$",
     )
 
     # weights
@@ -163,4 +179,71 @@ def add_variables(config: od.Config) -> None:
         binning=(40, 0.0, 400.0),
         unit="GeV",
         x_title=r"Jet 2 $p_{T}$",
+    )
+
+    # variables of interest
+    config.add_variable(
+        name="hh_mass",
+        expression="hh.mass",
+        binning=(20, 250, 750.0),
+        unit="GeV",
+        x_title=r"$m_{hh}$",
+    )
+    config.add_variable(
+        name="hh_pt",
+        expression="hh.pt",
+        binning=(100, 0, 500.0),
+        unit="GeV",
+        x_title=r"$p_T$",
+    )
+    config.add_variable(
+        name="hh_eta",
+        expression="hh.eta",
+        binning=(100, -3.0, 3.0),
+        unit="GeV",
+        x_title=r"$\eta$",
+    )
+
+    config.add_variable(
+        name="diTau_mass",
+        expression="diTau.mass",
+        binning=(20, 50, 200.0),
+        unit="GeV",
+        x_title=r"$m_{\tau\tau}$",
+    )
+    config.add_variable(
+        name="diTau_pt",
+        expression="diTau.pt",
+        binning=(100, 0, 500.0),
+        unit="GeV",
+        x_title=r"$p_T$",
+    )
+    config.add_variable(
+        name="diTau_eta",
+        expression="diTau.eta",
+        binning=(100, -3.0, 3.0),
+        unit="GeV",
+        x_title=r"$\eta$",
+    )
+
+    config.add_variable(
+        name="diBJet_mass",
+        expression="diBJet.mass",
+        binning=(20, 0, 500.0),
+        unit="GeV",
+        x_title=r"$m_{bb}$",
+    )
+    config.add_variable(
+        name="diBJet_pt",
+        expression="diBJet.pt",
+        binning=(100, 0, 500.0),
+        unit="GeV",
+        x_title=r"$p_T$",
+    )
+    config.add_variable(
+        name="diBJet_eta",
+        expression="diBJet.eta",
+        binning=(100, -3.0, 3.0),
+        unit="GeV",
+        x_title=r"$\eta$",
     )

--- a/hbt/inference/base.py
+++ b/hbt/inference/base.py
@@ -1,0 +1,237 @@
+# coding: utf-8
+
+"""
+Collection of helper functions for creating inference models
+"""
+
+import law
+import order as od
+
+from columnflow.inference import InferenceModel, ParameterType, ParameterTransformation
+from columnflow.util import maybe_import, DotDict
+from columnflow.config_util import get_datasets_from_process
+
+import hbt.inference.constants as const  # noqa
+
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+logger = law.logger.get_logger(__name__)
+
+
+class HBTInferenceModelBase(InferenceModel):
+    """
+    This is the base for all Inference models in our hbw analysis.
+    """
+
+    #
+    # Model attributes, can be changed via `cls.derive`
+    #
+
+    # default ml model, used for resolving defaults
+    ml_model_name: str = "dense_default"
+
+    # list of all processes/channels/systematics to include in the datacards
+    processes: list = []
+    channels: list = []
+    systematics: list = []
+
+    # customization of channels
+    mc_stats: bool = True
+    skip_data: bool = True
+
+    def __init__(self, config_inst: od.Config, *args, **kwargs):
+        super().__init__(config_inst)
+
+        self.add_inference_categories()
+        self.add_inference_processes()
+        self.add_inference_parameters()
+        # self.print_model()
+
+        #
+        # post-processing
+        #
+
+        self.cleanup()
+
+    def print_model(self):
+        """ Helper to print categories, processes and parameters of the InferenceModel """
+        for cat in self.categories:
+            print(f"{'=' * 20} {cat.name}")
+            print(f"Variable {cat.config_variable} \nCategory {cat.config_category}")
+            print(f"Processes {[p.name for p in cat.processes]}")
+            print(f"Parameters {set().union(*[[param.name for param in proc.parameters] for proc in cat.processes])}")
+
+    def cat_name(self: InferenceModel, config_cat_inst: od.Category):
+        """ Function to determine inference category name from config category """
+        # root_cats = config_cat_inst.x.root_cats
+        final_name = f"cat_{config_cat_inst.name}"
+        return final_name
+
+    # def config_variable(self: InferenceModel, config_cat_inst: od.Config):
+    #     """ Function to determine inference variable name from config category """
+    #     root_cats = config_cat_inst.x.root_cats
+    #     if dnn_cat := root_cats.get("dnn"):
+    #         dnn_proc = dnn_cat.replace("ml_", "")
+    #         return f"mlscore.{dnn_proc}"
+    #     else:
+    #         return "mli_mbb"
+
+    def customize_category(self: InferenceModel, cat_inst: DotDict, config_cat_inst: od.Config):
+        """ Function to allow customizing the inference category """
+        # root_cats = config_cat_inst.x.root_cats
+        # variables = ["jet1_pt"]
+        # if dnn_cat := root_cats.get("dnn"):
+        #     dnn_proc = dnn_cat.replace("ml_", "")
+        #     variables.append(f"mlscore.{dnn_proc}")
+        cat_inst.variables_to_plot = self.config_variable
+
+    def add_inference_categories(self: InferenceModel):
+        """
+        This function creates categories for the inference model
+        """
+
+        # get the MLModel inst
+        # ml_model_inst = MLModel.get_cls(self.ml_model_name)(self.config_inst)
+        for config_category in self.config_categories:
+            cat_inst = self.config_inst.get_category(config_category)
+            # root_cats = cat_inst.x.root_cats
+            # lep_channel = root_cats.get("lep")
+            # if lep_channel not in self.config_inst.x.lepton_channels:
+            #     raise Exception(
+            #         "Each inference category needs to be categorized based on number of leptons; "
+            #         f"Options: {self.config_inst.x.lepton_channels}",
+            #     )
+
+            cat_name = self.cat_name(cat_inst)
+            cat_kwargs = dict(
+                config_category=config_category,
+                config_variable=self.config_variable,
+                mc_stats=self.mc_stats,
+            )
+            if self.skip_data:
+                cat_kwargs["data_from_processes"] = self.processes
+            # else:
+            #     cat_kwargs["config_data_datasets"] = const.data_datasets[lep_channel]
+
+            self.add_category(cat_name, **cat_kwargs)
+
+            # do some customization of the inference category
+            self.customize_category(self.get_category(cat_name), cat_inst)
+
+    def add_inference_processes(self: InferenceModel):
+        """
+        Function that adds processes with their corresponding datasets to all categories
+        of the inference model
+        """
+        used_datasets = set()
+        for proc in self.processes:
+            if not self.config_inst.has_process(proc):
+                raise Exception(f"Process {proc} not included in the config {self.config_inst.name}")
+
+            # get datasets corresponding to this process
+            datasets = [
+                d.name for d in
+                get_datasets_from_process(self.config_inst, proc, strategy="inclusive")
+            ]
+            # hack for dy
+            if proc == "dy":
+                datasets = [x for x in datasets if x.startswith("dy_lep_pt")]
+
+            # check that no dataset is used multiple times
+            if datasets_already_used := used_datasets.intersection(datasets):
+                raise Exception(f"{datasets_already_used} datasets are used for multiple processes")
+            used_datasets |= set(datasets)
+
+            self.add_process(
+                const.inference_procnames.get(proc, proc),
+                config_process=proc,
+                is_signal=(any(x in proc for x in ["HH_", "hh_"])),
+                config_mc_datasets=datasets,
+            )
+
+    def add_inference_parameters(self: InferenceModel):
+        """
+        Function that adds all parameters (systematic variations) to the inference model
+        """
+        # define the two relevant types of parameter groups
+        self.add_parameter_group("experiment")
+        self.add_parameter_group("theory")
+
+        # add rate + shape parameters to the inference model
+        self.add_rate_parameters()
+        # self.add_shape_parameters()
+
+        # TODO: check that all requested systematics are in final MLModel?
+
+    def add_rate_parameters(self: InferenceModel):
+        """
+        Function that adds all rate parameters to the inference model
+        """
+        ecm = self.config_inst.campaign.ecm
+
+        # lumi
+        lumi = self.config_inst.x.luminosity
+        for unc_name in lumi.uncertainties:
+            if unc_name not in self.systematics:
+                continue
+
+            self.add_parameter(
+                unc_name,
+                type=ParameterType.rate_gauss,
+                effect=lumi.get(names=unc_name, direction=("down", "up"), factor=True),
+                transformations=[ParameterTransformation.symmetrize],
+            )
+            self.add_parameter_to_group(unc_name, "experiment")
+
+        # add QCD scale (rate) uncertainties to inference model
+        # TODO: combine scale and mtop uncertainties for specific processes?
+        # TODO: some scale/pdf uncertainties should be rounded to 3 digits, others to 4 digits
+        # NOTE: it might be easier to just take the recommended uncertainty values from HH conventions at
+        #       https://gitlab.cern.ch/hh/naming-conventions instead of taking the values from CMSDB
+        for k, procs in const.processes_per_QCDScale.items():
+            syst_name = f"QCDScale_{k}"
+            if syst_name not in self.systematics:
+                continue
+
+            for proc in procs:
+                if proc not in self.processes:
+                    continue
+                process_inst = self.config_inst.get_process(proc)
+                if "scale" not in process_inst.xsecs[ecm]:
+                    continue
+                self.add_parameter(
+                    syst_name,
+                    process=const.inference_procnames.get(proc, proc),
+                    type=ParameterType.rate_gauss,
+                    effect=tuple(map(
+                        lambda f: round(f, 3),
+                        process_inst.xsecs[ecm].get(names=("scale"), direction=("down", "up"), factor=True),
+                    )),
+                )
+            self.add_parameter_to_group(syst_name, "theory")
+
+        # add PDF rate uncertainties to inference model
+        for k, procs in const.processes_per_pdf_rate.items():
+            syst_name = f"pdf_{k}"
+            if syst_name not in self.systematics:
+                continue
+
+            for proc in procs:
+                if proc not in self.processes:
+                    continue
+                process_inst = self.config_inst.get_process(proc)
+                if "pdf" not in process_inst.xsecs[ecm]:
+                    continue
+
+                self.add_parameter(
+                    f"pdf_{k}",
+                    process=const.inference_procnames.get(proc, proc),
+                    type=ParameterType.rate_gauss,
+                    effect=tuple(map(
+                        lambda f: round(f, 3),
+                        process_inst.xsecs[ecm].get(names=("pdf"), direction=("down", "up"), factor=True),
+                    )),
+                )
+            self.add_parameter_to_group(syst_name, "theory")

--- a/hbt/inference/constants.py
+++ b/hbt/inference/constants.py
@@ -1,0 +1,113 @@
+# coding: utf-8
+
+"""
+Collection of configurations that stay constant for the analysis
+"""
+
+# collection of all signal processes
+signals_ggHH = {
+    # "ggHH_kl_0_kt_1_sl_hbbhww", "ggHH_kl_1_kt_1_sl_hbbhww",
+    # "ggHH_kl_2p45_kt_1_sl_hbbhww", "ggHH_kl_5_kt_1_sl_hbbhww",
+    "graviton_hh_ggf_bbtautau_m400",
+}
+signals_qqHH = {
+    # "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_0_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_2_sl_hbbhww",
+    # "qqHH_CV_1_C2V_0_kl_1_sl_hbbhww", "qqHH_CV_1_C2V_2_kl_1_sl_hbbhww",
+    # "qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww",
+    "graviton_hh_vbf_bbtautau_m400",
+}
+signals = {*signals_ggHH, *signals_qqHH}
+
+# mapping between lepton categories and datasets (only 2017 ATM)
+data_datasets = {
+    "1e": {f"data_e_{i}" for i in ["b", "c", "d", "e", "f"]},
+    "1mu": {f"data_mu_{i}" for i in ["b", "c", "d", "e", "f"]},
+    "2e": {"data_e_b"},  # TODO: 2 lep datasets in cmsdb + config
+    "2mu": {"data_mu_b"},  # TODO
+    "emu": {"data_mu_b"},  # TODO
+}
+merged_datasets = set().union(*data_datasets.values())
+
+# mapping between process names in the config and inference model
+inference_procnames = {
+    # key: config process name, value: inference model process name
+    "foo": "bar",
+    # "st": "ST",
+    # "tt": "TT",
+}
+
+# mapping, which processes are used for which QCDScale (rate) uncertainty
+processes_per_QCDScale = {
+    "ttbar": ["tt", "st_tchannel", "st_schannel", "st_twchannel", "ttW", "ttZ"],
+    "V": ["dy_lep", "w_lnu"],
+    "VV": ["WW", "ZZ", "WZ", "qqZZ"],
+    "VVV": ["vvv"],
+    "ggH": ["ggH"],
+    "qqH": ["qqH"],
+    "VH": ["ZH", "WH", "VH"],
+    "ttH": ["ttH", "tHq", "tHW"],
+    "bbH": ["bbH"],  # contains also pdf and alpha_s
+    # "ggHH": signals_ggHH,  # included in inference model (THU_HH)
+    "qqHH": signals_qqHH,
+    "VHH": [],
+    "ttHH": [],
+}
+
+# mapping, which processes are used for which pdf (rate) uncertainty
+processes_per_pdf_rate = {
+    "gg": ["tt", "ttZ", "ggZZ"],
+    "qqbar": ["st_schannel", "st_tchannel", "dy_lep", "w_lnu", "vvv", "qqZZ", "ttW"],
+    "qg": ["st_twchannel"],
+    "Higgs_gg": ["ggH"],
+    "Higgs_qqbar": ["qqH", "ZH", "WH", "VH"],
+    # "Higgs_qg": [],  # none so far
+    "Higgs_ttH": ["ttH", "tHq", "tHW"],
+    # "Higgs_bbh": ["bbH"],  # removed
+    "Higgs_ggHH": signals_ggHH,
+    "Higgs_qqHH": signals_qqHH,
+    "Higgs_VHH": ["HHZ", "HHW+", "HHW-"],
+    "Higgs_ttHH": ["ttHH"],
+}
+
+# mapping for each shape uncertainty, which process is used.
+# If "all" is included, takes all processes except for the ones specified (starting with !)
+processes_per_shape = {
+    "btag_hf": ["all"],
+    "btag_lf": ["all"],
+    "btag_hfstats1_2017": ["all"],
+    "btag_hfstats2_2017": ["all"],
+    "btag_lfstats1_2017": ["all"],
+    "btag_lfstats2_2017": ["all"],
+    "btag_cferr1": ["all"],
+    "btag_cferr2": ["all"],
+    "mu_trig": ["all"],
+    "e_sf": ["all"],
+    "e_trig": ["all"],
+    "minbias_xs": ["all"],
+    "top_pt": ["all"],
+    "pdf_shape_ggHH_kl_0_kt_1_sl_hbbhww": ["ggHH_kl_0_kt_1_sl_hbbhww"],
+    "pdf_shape_ggHH_kl_1_kt_1_sl_hbbhww": ["ggHH_kl_1_kt_1_sl_hbbhww"],
+    "pdf_shape_ggHH_kl_2p45_kt_1_sl_hbbhww": ["ggHH_kl_2p45_kt_1_sl_hbbhww"],
+    "pdf_shape_ggHH_kl_5_kt_1_sl_hbbhww": ["ggHH_kl_5_kt_1_sl_hbbhww"],
+    "pdf_shape_tt": ["tt"],
+    "pdf_shape_st": ["st_schannel", "st_twchannel"],  # TODO: there was some bug with "st_tchannel"
+    "pdf_shape_dy": ["dy_lep"],
+    "pdf_shape_w": ["w_lnu"],
+    "murf_envelope_ggHH_kl_0_kt_1_sl_hbbhww": ["ggHH_kl_0_kt_1_sl_hbbhww"],
+    "murf_envelope_ggHH_kl_1_kt_1_sl_hbbhww": ["ggHH_kl_1_kt_1_sl_hbbhww"],
+    "murf_envelope_ggHH_kl_2p45_kt_1_sl_hbbhww": ["ggHH_kl_2p45_kt_1_sl_hbbhww"],
+    "murf_envelope_ggHH_kl_5_kt_1_sl_hbbhww": ["ggHH_kl_5_kt_1_sl_hbbhww"],
+    "murf_envelope_tt": ["tt"],
+    "murf_envelope_st": ["st_schannel", "st_tchannel", "st_twchannel"],
+    "murf_envelope_dy": ["dy_lep"],
+    "murf_envelope_w": ["w_lnu"],
+}
+
+# mapping for each shape uncertainty, which shift source is used
+# per default: shape and source have the same name (except for pdf and murf, which are implemented per process)
+source_per_shape = {shape: shape for shape in processes_per_shape.keys()}
+for shape in processes_per_shape.keys():
+    if "pdf_shape" in shape:
+        source_per_shape[shape] = "pdf"
+    elif "murf_envelope" in shape:
+        source_per_shape[shape] = "murf_envelope"

--- a/hbt/inference/derived.py
+++ b/hbt/inference/derived.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+
+"""
+hbw inference model.
+"""
+
+import hbt.inference.constants as const  # noqa
+from hbt.inference.base import HBTInferenceModelBase
+
+
+#
+# Defaults for all the Inference Model parameters
+#
+
+# used to set default requirements for cf.CreateDatacards based on the config
+ml_model_name = "4classes_DeepSets_no_neg_weights"
+
+# default_producers = [f"ml_{ml_model_name}", "event_weights"]
+
+# All processes to be included in the final datacard
+processes = [
+    "graviton_hh_ggf_bbtautau_m400",
+    "graviton_hh_vbf_bbtautau_m400",
+    "tt",
+    "dy",
+]
+
+# All config categories to be included in the final datacard
+config_categories = [
+    f"incl__ml_{proc}" for proc in processes
+]
+
+rate_systematics = [
+    # Lumi: should automatically choose viable uncertainties based on campaign
+    "lumi_13TeV_2016",
+    "lumi_13TeV_2017",
+    "lumi_13TeV_1718",
+    "lumi_13TeV_correlated",
+    # Rate QCDScale uncertainties
+    "QCDScale_ttbar",
+    "QCDScale_V",
+    "QCDScale_VV",
+    "QCDScale_VVV",
+    "QCDScale_ggH",
+    "QCDScale_qqH",
+    "QCDScale_VH",
+    "QCDScale_ttH",
+    "QCDScale_bbH",
+    "QCDScale_ggHH",  # should be included in inference model (THU_HH)
+    "QCDScale_qqHH",
+    "QCDScale_VHH",
+    "QCDScale_ttHH",
+    # Rate PDF uncertainties
+    "pdf_gg",
+    "pdf_qqbar",
+    "pdf_qg",
+    "pdf_Higgs_gg",
+    "pdf_Higgs_qqbar",
+    "pdf_Higgs_qg",  # none so far
+    "pdf_Higgs_ttH",
+    "pdf_Higgs_bbH",  # removed
+    "pdf_Higgs_ggHH",
+    "pdf_Higgs_qqHH",
+    "pdf_VHH",
+    "pdf_ttHH",
+]
+
+# All systematics to be included in the final datacard
+systematics = rate_systematics
+
+default_cls_dict = {
+    "ml_model_name": ml_model_name,
+    "processes": processes,
+    "config_categories": config_categories,
+    "systematics": systematics,
+    "mc_stats": True,
+    "skip_data": True,
+}
+
+default = HBTInferenceModelBase.derive(
+    f"rates_only_{default_cls_dict['ml_model_name']}", cls_dict=default_cls_dict,
+)
+
+ggf_cls_dict = {
+    "ml_model_name": ml_model_name,
+    "processes": processes,
+    "config_categories": ["incl"],
+    "systematics": systematics,
+    "mc_stats": True,
+    "skip_data": True,
+    "config_variable": lambda inference_model, config_cat_inst: "mlscore.graviton_hh_ggf_bbtautau_m400",
+}
+
+ml_score_ggf = HBTInferenceModelBase.derive(
+    f"ggf_only_{default_cls_dict['ml_model_name']}", cls_dict=ggf_cls_dict,
+)
+
+#
+# derive some additional Inference Models
+#
+
+cls_dict = default_cls_dict.copy()
+
+cls_dict["systematics"] = rate_systematics
+# inference model with only rate uncertainties
+# sl_rates_only = default.derive("rates_only", cls_dict=cls_dict)
+
+cls_dict["processes"] = [
+    "graviton_hh_ggf_bbtautau_m400",
+    "graviton_hh_vbf_bbtautau_m400",
+    "tt",
+    "dy",
+]
+
+cls_dict["config_categories"] = [
+    "1e__ml_ggHH_kl_1_kt_1_sl_hbbhww",
+    "1e__ml_st",
+]
+
+cls_dict["systematics"] = [
+    "lumi_13TeV_2017",
+]
+
+cls_dict["ml_model_name"] = "dense_test"
+
+# minimal model for quick test purposes
+test = default.derive("test", cls_dict=cls_dict)
+
+# model but with different fit variable
+cls_dict["config_variable"] = lambda config_cat_inst: "jet1_pt"
+jet1_pt = default.derive("jet1_pt", cls_dict=cls_dict)

--- a/hbt/inference/dl.py
+++ b/hbt/inference/dl.py
@@ -1,0 +1,156 @@
+# coding: utf-8
+
+"""
+hbw(dl) inference model.
+"""
+
+import hbt.inference.constants as const  # noqa
+from hbt.inference.base import HBTInferenceModelBase
+
+
+#
+# Defaults for all the Inference Model parameters
+#
+
+# used to set default requirements for cf.CreateDatacards based on the config
+ml_model_name = "dense_default_dl"
+# default_producers = [f"ml_{ml_model_name}", "event_weights"]
+
+# All processes to be included in the final datacard
+processes = [
+    "graviton_hh_ggf_bbtautau_m400",
+    "graviton_hh_vbf_bbtautau_m400",
+    "tt",
+    "dy",
+]
+
+# All categories to be included in the final datacard
+config_categories = [
+    "2e__ml_ggHH_kl_1_kt_1_dl_hbbhww",
+    "2e__ml_qqHH_CV_1_C2V_1_kl_1_dl_hbbhww",
+    "2e__ml_tt",
+    "2e__ml_t_bkg",
+    "2e__ml_st",
+    "2e__ml_sig",
+    "2e__ml_v_lep",
+    "2mu__ml_ggHH_kl_1_kt_1_dl_hbbhww",
+    "2mu__ml_qqHH_CV_1_C2V_1_kl_1_dl_hbbhww",
+    "2mu__ml_tt",
+    "2mu__ml_tt_bkg",
+    "2mu__ml_st",
+    "2mu__ml_sig",
+    "2mu__ml_v_lep",
+]
+
+rate_systematics = [
+    # Lumi: should automatically choose viable uncertainties based on campaign
+    "lumi_13TeV_2016",
+    "lumi_13TeV_2017",
+    "lumi_13TeV_1718",
+    "lumi_13TeV_correlated",
+    # Rate QCDScale uncertainties
+    "QCDScale_ttbar",
+    "QCDScale_V",
+    "QCDScale_VV",
+    "QCDScale_VVV",
+    "QCDScale_ggH",
+    "QCDScale_qqH",
+    "QCDScale_VH",
+    "QCDScale_ttH",
+    "QCDScale_bbH",
+    "QCDScale_ggHH",  # should be included in inference model (THU_HH)
+    "QCDScale_qqHH",
+    "QCDScale_VHH",
+    "QCDScale_ttHH",
+    # Rate PDF uncertainties
+    "pdf_gg",
+    "pdf_qqbar",
+    "pdf_qg",
+    "pdf_Higgs_gg",
+    "pdf_Higgs_qqbar",
+    "pdf_Higgs_qg",  # none so far
+    "pdf_Higgs_ttH",
+    "pdf_Higgs_bbH",  # removed
+    "pdf_Higgs_ggHH",
+    "pdf_Higgs_qqHH",
+    "pdf_VHH",
+    "pdf_ttHH",
+]
+
+shape_systematics = [
+    # Shape Scale uncertainties
+    # "murf_envelope_ggHH_kl_1_kt_1_dl_hbbhww",
+    "murf_envelope_tt",
+    "murf_envelope_st_schannel",
+    "murf_envelope_st_tchannel",
+    "murf_envelope_st_twchannel",
+    "murf_envelope_dy_lep",
+    "murf_envelope_w_lnu",
+    "murf_envelope_ttV",
+    "murf_envelope_VV",
+    # Shape PDF Uncertainties
+    "pdf_shape_tt",
+    "pdf_shape_st_schannel",
+    "pdf_shape_st_tchannel",
+    "pdf_shape_st_twchannel",
+    "pdf_shape_dy_lep",
+    "pdf_shape_w_lnu",
+    "pdf_shape_ttV",
+    "pdf_shape_VV",
+    # Scale Factors (TODO)
+    "btag_hf",
+    "btag_lf",
+    "btag_hfstats1_2017",
+    "btag_hfstats2_2017"
+    "btag_lfstats1_2017"
+    "btag_lfstats2_2017"
+    "btag_cferr1",
+    "btag_cferr2",
+    "mu_sf",
+    # "mu_trig",
+    "e_sf",
+    # "e_trig",
+    # "minbias_xs",
+    # "top_pt",
+]
+
+# All systematics to be included in the final datacard
+systematics = rate_systematics + shape_systematics
+
+default_cls_dict = {
+    "ml_model_name": ml_model_name,
+    "processes": processes,
+    "config_categories": config_categories,
+    "systematics": systematics,
+    "mc_stats": True,
+    "skip_data": True,
+}
+
+dl = HBTInferenceModelBase.derive("dl", cls_dict=default_cls_dict)
+
+cls_dict = default_cls_dict.copy()
+
+cls_dict["processes"] = [
+    # "ggHH_kl_0_kt_1_dl_hbbhww",
+    "graviton_hh_ggf_bbtautau_m400",
+    # "ggHH_kl_2p45_kt_1_dl_hbbhww",
+    # "ggHH_kl_5_kt_1_dl_hbbhww",
+    "tt",
+]
+
+cls_dict["config_categories"] = [
+    # "2e__ml_ggHH_kl_1_kt_1_dl_hbbhww",
+    # "2e__ml_tt",
+    "2j",
+]
+
+cls_dict["config_variable"] = "jet_pt"
+
+cls_dict["systematics"] = [
+    "lumi_13TeV_2017",
+]
+
+cls_dict["ml_model_name"] = "dense_test_dl"
+
+# minimal model for quick test purposes
+dl_test = dl.derive("dl_test", cls_dict=cls_dict)

--- a/hbt/inference/grav_model.py
+++ b/hbt/inference/grav_model.py
@@ -1,0 +1,62 @@
+from columnflow.inference import inference_model, ParameterType
+
+
+@inference_model
+def grav_model(self):
+
+    #
+    # categories
+    #
+
+    for mass in ["400", "450", "500"]:
+        self.add_category(
+            f"cat{mass}",
+            config_category="incl",
+            config_variable="jet1_pt",
+            # fake data from TT
+            data_from_processes=["TT"],
+            mc_stats=True,
+        )
+
+    #
+    # processes
+    #
+    for mass in ["400", "450", "500"]:
+        self.add_process(
+            f"ggf_spin_2_mass_{mass}_hbbhtt",
+            is_signal=True,
+            config_process=f"graviton_hh_ggf_bbtautau_m{mass}",
+            category=f"cat{mass}",
+        )
+
+    self.add_process(
+        "TT",
+        config_process="tt_sl",
+    )
+
+    #
+    # parameters
+    #
+
+    # groups
+    self.add_parameter_group("experiment")
+    self.add_parameter_group("theory")
+
+    # lumi
+    lumi = self.config_inst.x.luminosity
+    for unc_name in lumi.uncertainties:
+        self.add_parameter(
+            unc_name,
+            type=ParameterType.rate_gauss,
+            effect=lumi.get(names=unc_name, direction=("down", "up"), factor=True),
+        )
+        self.add_parameter_to_group(unc_name, "experiment")
+
+    # a custom asymmetric uncertainty that is converted from rate to shape
+    self.add_parameter(
+        "QCDscale_ttbar",
+        process="TT",
+        type=ParameterType.rate_gauss,
+        effect=(0.85, 1.1),
+    )
+    self.add_parameter_to_group("QCDscale_ttbar", "experiment")

--- a/hbt/inference/test_unc.py
+++ b/hbt/inference/test_unc.py
@@ -1,0 +1,70 @@
+from columnflow.inference import inference_model, ParameterType
+
+
+@inference_model
+def test_unc(self):
+    self.add_category(
+        "channel",
+        config_category="incl",
+        config_variable="e_pt",
+        # fake data
+        data_from_processes=["TT", "dy"],
+        mc_stats=True,
+    )
+
+    #
+    # processes
+    #
+    self.add_process(
+        "dy",
+        config_process="dy",
+    )
+
+    self.add_process(
+        "TT",
+        config_process="tt_sl",
+    )
+
+    self.add_process(
+        "hh_ggf",
+        is_signal=True,
+        config_process="hh_ggf_bbtautau",
+    )
+
+    #
+    # parameters
+    #
+
+    # groups
+    self.add_parameter_group("experiment")
+    self.add_parameter_group("theory")
+
+    # lumi
+    lumi = self.config_inst.x.luminosity
+    for unc_name in lumi.uncertainties:
+        self.add_parameter(
+            unc_name,
+            type=ParameterType.rate_gauss,
+            effect=lumi.get(names=unc_name, direction=("down", "up"), factor=True),
+        )
+        self.add_parameter_to_group(unc_name, "experiment")
+
+    # a custom asymmetric uncertainty
+    """
+    self.add_parameter(
+        "QCDscale_ttbar",
+        process="TT",
+        type=ParameterType.shape,
+        transformations=[ParameterTransformation.effect_from_rate],
+        effect=(0.85, 1.1),
+    )
+    self.add_parameter_to_group("QCDscale_ttbar", "experiment")
+    """
+    # tune uncertainty
+    self.add_parameter(
+        "tune",
+        process="TT",
+        type=ParameterType.shape,
+        config_shift_source="tune",
+    )
+    self.add_parameter_to_group("tune", "experiment")

--- a/hbt/production/empty.py
+++ b/hbt/production/empty.py
@@ -1,0 +1,42 @@
+# coding: utf-8
+
+"""
+Empty producers.
+"""
+
+from columnflow.production import Producer, producer
+from columnflow.production.normalization import normalization_weights
+from columnflow.production.categories import category_ids
+from columnflow.util import maybe_import
+# from hbt.production.btag import normalized_btag_weights
+# from columnflow.production.cms.electron import electron_weights
+# from columnflow.production.cms.muon import muon_weights
+# from hbt.production.features import features
+# from hbt.production.weights import normalized_pu_weight, normalized_pdf_weight, normalized_murmuf_weight
+# from hbt.production.tau import tau_weights, trigger_weights
+
+ak = maybe_import("awkward")
+
+
+@producer(
+    uses={
+        category_ids, normalization_weights,
+    },
+    produces={
+        category_ids, normalization_weights,
+    },
+)
+def empty(
+    self: Producer,
+    events: ak.Array,
+    **kwargs,
+) -> ak.Array:
+    # category ids
+    events = self[category_ids](events, **kwargs)
+
+    # mc-only weights
+    if self.dataset_inst.is_mc:
+        # normalization weights
+        events = self[normalization_weights](events, **kwargs)
+
+    return events

--- a/hbt/production/features.py
+++ b/hbt/production/features.py
@@ -12,7 +12,6 @@ from columnflow.production.cms.mc_weight import mc_weight
 from columnflow.util import maybe_import
 from columnflow.columnar_util import EMPTY_FLOAT, Route, set_ak_column
 
-
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
 
@@ -28,16 +27,17 @@ set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
     },
     produces={
         # new columns
-        "ht", "n_jet", "n_hhbtag", "n_electron", "n_muon",
+        "n_electron", "ht", "n_jet", "n_hhbtag", "n_electron", "n_muon",
     },
 )
 def features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+
+    events = set_ak_column_i32(events, "n_electron", ak.num(events.Electron.pt, axis=1))
     events = set_ak_column_f32(events, "ht", ak.sum(events.Jet.pt, axis=1))
     events = set_ak_column_i32(events, "n_jet", ak.num(events.Jet.pt, axis=1))
     events = set_ak_column_i32(events, "n_hhbtag", ak.num(events.HHBJet.pt, axis=1))
     events = set_ak_column_i32(events, "n_electron", ak.num(events.Electron.pt, axis=1))
     events = set_ak_column_i32(events, "n_muon", ak.num(events.Muon.pt, axis=1))
-
     return events
 
 
@@ -45,13 +45,14 @@ def features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     uses={
         mc_weight, category_ids,
         # nano columns
-        "Jet.pt", "Jet.eta", "Jet.phi",
+        "Jet.pt", "Jet.eta", "Jet.phi", "Electron.pt",
     },
     produces={
         mc_weight, category_ids,
         # new columns
         "cutflow.n_jet", "cutflow.n_jet_selected", "cutflow.ht", "cutflow.jet1_pt",
-        "cutflow.jet1_eta", "cutflow.jet1_phi", "cutflow.jet2_pt",
+        "cutflow.jet1_eta", "cutflow.jet1_phi", "cutflow.jet2_pt", "cutflow.n_ele",
+        "cutflow.n_ele_selected",
     },
 )
 def cutflow_features(
@@ -64,6 +65,11 @@ def cutflow_features(
         events = self[mc_weight](events, **kwargs)
 
     events = self[category_ids](events, **kwargs)
+
+    selected_ele = events.Electron[object_masks["Electron"]["Electron"]]
+
+    events = set_ak_column_i32(events, "cutflow.n_ele", ak.num(events.Electron, axis=1))
+    events = set_ak_column_i32(events, "cutflow.n_ele_selected", ak.num(selected_ele, axis=1))
 
     # apply per-object selections
     selected_jet = events.Jet[object_masks["Jet"]["Jet"]]

--- a/hbt/production/hh_mass.py
+++ b/hbt/production/hh_mass.py
@@ -1,0 +1,80 @@
+import functools
+from columnflow.production import Producer, producer
+from columnflow.util import maybe_import
+from columnflow.columnar_util import EMPTY_FLOAT, set_ak_column
+from columnflow.production.util import attach_coffea_behavior
+from columnflow.production.categories import category_ids
+from columnflow.production.normalization import normalization_weights
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
+
+
+@producer(
+    uses=(
+        "Electron.*", "Tau.*", "Jet.*", "HHBJet.*",
+        category_ids, normalization_weights, attach_coffea_behavior,
+    ),
+    produces={
+        "hh.*", "diTau.*", "diBJet.*", category_ids, normalization_weights,
+    },
+)
+def hh_mass(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    # category ids
+    events = self[category_ids](events, **kwargs)
+
+    events = self[attach_coffea_behavior](
+        events,
+        collections={"HHBJet": {"type_name": "Jet"}},
+        **kwargs,
+    )
+
+    # mc-only weights
+    if self.dataset_inst.is_mc:
+        # normalization weights
+        events = self[normalization_weights](events, **kwargs)
+
+        # btag weights
+        # events = self[normalized_btag_weights](events, **kwargs)
+
+    # total number of objects per event
+    n_bjets = ak.num(events.HHBJet, axis=1)
+    n_taus = ak.num(events.Tau, axis=1)
+    # mask to select events with exactly 2 taus
+    ditau_mask = (n_taus == 2)
+    diBjet_mask = (n_bjets == 2)
+    dihh_mask = ditau_mask & diBjet_mask
+
+    # four-vector sum of first two elements of each object collection (possibly fewer)
+    diBJet = events.HHBJet.sum(axis=1)
+    diTau = events.Tau[:, :2].sum(axis=1)
+    hh = diBJet + diTau
+
+    def save_interesting_properties(
+        source: ak.Array,
+        target_column: str,
+        column_values: ak.Array,
+        mask: ak.Array[bool],
+    ):
+        return set_ak_column_f32(
+            source, target_column,
+            ak.where(mask, column_values, EMPTY_FLOAT),
+        )
+
+    # write out variables to the corresponding events array, applying the diTau mask
+    events = save_interesting_properties(events, "diBJet.mass", diBJet.mass, diBjet_mask)
+    events = save_interesting_properties(events, "diBJet.eta", diBJet.eta, diBjet_mask)
+    events = save_interesting_properties(events, "diBJet.pt", diBJet.pt, diBjet_mask)
+
+    events = save_interesting_properties(events, "diTau.mass", diTau.mass, ditau_mask)
+    events = save_interesting_properties(events, "diTau.eta", diTau.eta, ditau_mask)
+    events = save_interesting_properties(events, "diTau.pt", diTau.pt, ditau_mask)
+
+    events = save_interesting_properties(events, "hh.mass", hh.mass, dihh_mask)
+    events = save_interesting_properties(events, "hh.eta", hh.eta, dihh_mask)
+    events = save_interesting_properties(events, "hh.pt", hh.pt, dihh_mask)
+
+    # return the events
+    return events

--- a/hbt/selection/default.py
+++ b/hbt/selection/default.py
@@ -54,10 +54,6 @@ def default(
     # ensure coffea behavior
     events = self[attach_coffea_behavior](events, **kwargs)
 
-    # add corrected mc weights
-    if self.dataset_inst.is_mc:
-        events = self[mc_weight](events, **kwargs)
-
     # prepare the selection results that are updated at every step
     results = SelectionResult()
 
@@ -84,6 +80,8 @@ def default(
 
     # mc-only functions
     if self.dataset_inst.is_mc:
+        events = self[mc_weight](events, **kwargs)
+
         # pdf weights
         events = self[pdf_weights](events, **kwargs)
 

--- a/hbt/selection/default_custom.py
+++ b/hbt/selection/default_custom.py
@@ -1,0 +1,104 @@
+# coding: utf-8
+
+"""
+Empty selectors + trigger selection
+"""
+
+from operator import and_
+from functools import reduce
+from collections import defaultdict
+from columnflow.selection import Selector, SelectionResult, selector
+from columnflow.selection.stats import increment_stats
+from columnflow.production.processes import process_ids
+# from columnflow.selection.cms.met_filters import met_filters
+from columnflow.production.categories import category_ids
+from columnflow.production.cms.mc_weight import mc_weight
+from columnflow.production.util import attach_coffea_behavior
+from columnflow.util import maybe_import, dev_sandbox
+from hbt.selection.trigger import trigger_selection
+from hbt.selection.lepton import lepton_selection
+from hbt.production.features import cutflow_features
+from hbt.selection.jet import jet_selection
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+@selector(
+    uses={
+        process_ids, mc_weight, increment_stats, cutflow_features, trigger_selection,
+        lepton_selection, attach_coffea_behavior, category_ids, jet_selection,
+    },
+    produces={
+        process_ids, mc_weight, cutflow_features, trigger_selection, jet_selection,
+        lepton_selection, category_ids,
+    },
+    sandbox=dev_sandbox("bash::$HBT_BASE/sandboxes/venv_columnar_tf.sh"),
+    exposed=True,
+)
+def default_custom(
+    self: Selector,
+    events: ak.Array,
+    stats: defaultdict,
+    **kwargs,
+) -> tuple[ak.Array, SelectionResult]:
+    # ensure coffea behavior
+    events = self[attach_coffea_behavior](events, **kwargs)
+
+    # add corrected mc weights
+    if self.dataset_inst.is_mc:
+        events = self[mc_weight](events, **kwargs)
+
+    # prepare the selection results that are updated at every step
+    results = SelectionResult()
+
+    # met filter selection TODO
+    # events, met_filter_results = self[met_filters](events, **kwargs)
+    # results += met_filter_results
+
+    # trigger selection
+    events, trigger_results = self[trigger_selection](events, **kwargs)
+    results += trigger_results
+
+    # lepton selection
+    events, lepton_results = self[lepton_selection](events, trigger_results, **kwargs)
+    results += lepton_results
+
+    # jet selection
+    events, jet_results = self[jet_selection](events, trigger_results, lepton_results, **kwargs)
+    results += jet_results
+
+    # combined event selection after all steps
+    event_sel = reduce(and_, results.steps.values())
+    results.event = event_sel
+
+    # write out process/category IDs
+    events = self[process_ids](events, **kwargs)
+    events = self[category_ids](events, **kwargs)
+
+    # increment stats
+    weight_map = {
+        "num_events": Ellipsis,
+        "num_events_selected": Ellipsis,
+    }
+    if self.dataset_inst.is_mc:
+        weight_map["sum_mc_weight"] = events.mc_weight
+        weight_map["sum_mc_weight_selected"] = (events.mc_weight, Ellipsis)
+
+        group_map = {
+            # per process
+            "process": {
+                "values": events.process_id,
+                "mask_fn": (lambda v: events.process_id == v),
+            },
+        }
+    events, results = self[increment_stats](
+        events,
+        results,
+        stats,
+        weight_map=weight_map,
+        group_map=group_map,
+        **kwargs,
+    )
+
+    return events, results

--- a/hbt/selection/empty.py
+++ b/hbt/selection/empty.py
@@ -1,0 +1,112 @@
+# coding: utf-8
+
+"""
+Empty selectors that still produce the minimal set of columns potentially required in downstream
+tasks.
+"""
+
+from collections import defaultdict
+
+from columnflow.selection import Selector, SelectionResult, selector
+from columnflow.selection.stats import increment_stats
+from columnflow.production.processes import process_ids
+from columnflow.production.cms.mc_weight import mc_weight
+from columnflow.columnar_util import set_ak_column
+from columnflow.util import maybe_import
+
+from hbt.production.spin_observables import gen_lep_tau
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+@selector(
+    uses={
+        process_ids, mc_weight, increment_stats, gen_lep_tau,
+    },
+    produces={
+        process_ids, mc_weight, "category_ids", gen_lep_tau,
+    },
+    exposed=True,
+    # hard-coded category ids
+    category_ids=None,
+    # name of the inclusive category for looking it up
+    inclusive_category_name="incl",
+)
+def empty(
+    self: Selector,
+    events: ak.Array,
+    stats: defaultdict,
+    **kwargs,
+) -> tuple[ak.Array, SelectionResult]:
+    """
+    Empty selector that only writes a minimal set of columns that are potentially required in
+    downstream tasks, such as cutflow and plotting related tasks.
+
+    :param events: The input events.
+    :param stats: The statistics dictionary.
+    :param **kwargs: Additional keyword arguments that are passed to all other
+        :py:class:`TaskArrayFunction`'s.
+
+    :returns: A tuple containing the original events and a :py:class:`SelectionResult` object with a
+        trivial event mask.
+    """
+    # create process ids
+    events = self[process_ids](events, **kwargs)
+
+    # add corrected mc weights
+    if self.dataset_inst.is_mc:
+        events = self[mc_weight](events, **kwargs)
+
+    # category id
+    category_ids = np.array(len(events) * [self.category_ids], dtype=np.int64)
+    events = set_ak_column(events, "category_ids", category_ids)
+
+    # empty selection result with a trivial event mask
+    results = SelectionResult(event=ak.Array(np.ones(len(events), dtype=np.bool_)))
+
+    # increment stats
+    weight_map = {
+        "num_events": Ellipsis,
+        "num_events_selected": Ellipsis,
+    }
+    if self.dataset_inst.is_mc:
+        weight_map["sum_mc_weight"] = events.mc_weight
+        weight_map["sum_mc_weight_selected"] = (events.mc_weight, Ellipsis)
+    group_map = {
+        # per process
+        "process": {
+            "values": events.process_id,
+            "mask_fn": (lambda v: events.process_id == v),
+        },
+    }
+    events, _ = self[increment_stats](
+        events,
+        results,
+        stats,
+        weight_map=weight_map,
+        group_map=group_map,
+        **kwargs,
+    )
+    events = self[gen_lep_tau](events, **kwargs)
+    return events, results
+
+
+@empty.init
+def empty_init(self: Selector) -> None:
+    """
+    Initializes the selector by finding the id of the inclusive category if no hard-coded category
+    ids are given on class-level.
+
+    :raises ValueError: If the inclusive category cannot be found.
+    """
+    # do nothing when category ids are set
+    if self.category_ids is not None:
+        return
+
+    # find the id of the inclusive category
+    if self.inclusive_category_name in self.config_inst.categories:
+        self.category_ids = [self.config_inst.categories.get(self.inclusive_category_name).id]
+    elif 1 in self.config_inst.categories:
+        self.category_ids = [1]
+    else:
+        raise ValueError(f"could not find inclusive category for {self.cls_name} selector")

--- a/hbt/selection/lepton.py
+++ b/hbt/selection/lepton.py
@@ -10,7 +10,7 @@ from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.columnar_util import set_ak_column
 from columnflow.util import DotDict, maybe_import
 
-from hbt.util import IF_NANO_V9, IF_NANO_V11
+from hbt.util import IF_NANO_V9, IF_NANO_GE_V11
 from hbt.config.util import Trigger
 
 
@@ -44,7 +44,7 @@ def trigger_object_matching(
         "Electron.pt", "Electron.eta", "Electron.phi", "Electron.dxy", "Electron.dz",
         "Electron.pfRelIso03_all",
         IF_NANO_V9("Electron.mvaFall17V2Iso_WP80", "Electron.mvaFall17V2Iso_WP90", "Electron.mvaFall17V2noIso_WP90"),
-        IF_NANO_V11("Electron.mvaIso_WP80", "Electron.mvaIso_WP90", "Electron.mvaNoIso_WP90"),
+        IF_NANO_GE_V11("Electron.mvaIso_WP80", "Electron.mvaIso_WP90", "Electron.mvaNoIso_WP90"),
         "TrigObj.pt", "TrigObj.eta", "TrigObj.phi",
     },
     exposed=False,
@@ -57,7 +57,7 @@ def electron_selection(
     **kwargs,
 ) -> tuple[ak.Array, ak.Array]:
     """
-    Electron selection returning two sets of indidces for default and veto electrons.
+    Electron selection returning two sets of indices for default and veto electrons.
     See https://twiki.cern.ch/twiki/bin/view/CMS/EgammaNanoAOD?rev=4
     """
     is_single = trigger.has_tag("single_e")
@@ -84,6 +84,8 @@ def electron_selection(
     # obtain mva flags, which might be located at different routes, depending on the nano version
     if "mvaIso_WP80" in events.Electron.fields:
         # >= nano v10
+        # beware that the available Iso should be mvaFall17V2 for run2 files, not Winter22V1,
+        # check this in original root files if necessary
         mva_iso_wp80 = events.Electron.mvaIso_WP80
         mva_iso_wp90 = events.Electron.mvaIso_WP90
         # mva_noniso_wp90 = events.Electron.mvaNoIso_WP90
@@ -281,8 +283,8 @@ def tau_selection(
         min_pt = 20.0
         max_eta = 2.3
     elif is_cross_e:
-        # only existing after 2016, so force a failure in case of misconfiguration
-        min_pt = None if is_2016 else 35.0
+        # only existing after 2016
+        min_pt = 0.0 if is_2016 else 35.0
         max_eta = 2.1
     elif is_cross_mu:
         min_pt = 25.0 if is_2016 else 32.0
@@ -291,8 +293,8 @@ def tau_selection(
         min_pt = 40.0
         max_eta = 2.1
     elif is_cross_tau_vbf:
-        # only existing after 2016, so force in failure in case of misconfiguration
-        min_pt = None if is_2016 else 25.0
+        # only existing after 2016
+        min_pt = 0.0 if is_2016 else 25.0
         max_eta = 2.1
 
     # base tau mask for default and qcd sideband tau

--- a/hbt/selection/trigger.py
+++ b/hbt/selection/trigger.py
@@ -45,7 +45,15 @@ def trigger_selection(
             continue
 
         # get bare decisions
-        fired = events.HLT[trigger.hlt_field] == 1
+
+        try:
+            fired = events.HLT[trigger.hlt_field] == 1
+        except:
+            import traceback
+            traceback.print_exc()
+            from IPython import embed
+            embed(header="trigger selection")
+
         any_fired = any_fired | fired
 
         # get trigger objects for fired events per leg

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -6,7 +6,7 @@ Helpful utils.
 
 from __future__ import annotations
 
-__all__ = ["IF_NANO_V9", "IF_NANO_V11"]
+__all__ = ["IF_NANO_V9", "IF_NANO_GE_V11"]
 
 from columnflow.types import Any
 from columnflow.columnar_util import ArrayFunction, deferred_column
@@ -18,5 +18,5 @@ def IF_NANO_V9(self: ArrayFunction.DeferredColumn, func: ArrayFunction) -> Any |
 
 
 @deferred_column
-def IF_NANO_V11(self: ArrayFunction.DeferredColumn, func: ArrayFunction) -> Any | set[Any]:
-    return self.get() if func.config_inst.campaign.x.version == 11 else None
+def IF_NANO_GE_V11(self: ArrayFunction.DeferredColumn, func: ArrayFunction) -> Any | set[Any]:
+    return self.get() if func.config_inst.campaign.x.version >= 11 else None

--- a/law.cfg
+++ b/law.cfg
@@ -30,12 +30,12 @@ default_analysis: hbt.config.analysis_hbt.analysis_hbt
 default_config: run2_2017_nano_uhh_v11_limited
 default_dataset: graviton_hh_ggf_bbtautau_m400_madgraph
 
-production_modules: columnflow.production.{categories,normalization,processes}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds,gen_top_decay}, hbt.production.{default,weights,features,btag,tau}
-calibration_modules: columnflow.calibration.cms.{jets,met}, hbt.calibration.{default,jet,tau}
-selection_modules: columnflow.selection.cms.{json_filter, met_filters}, hbt.selection.{default,lepton,trigger,jetmet}
+production_modules: columnflow.production.{categories,normalization,processes}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds,gen_top_decay}, hbt.production.{default,weights,features,btag,tau,empty,hh_mass}
+calibration_modules: columnflow.calibration.cms.{jets,met}, hbt.calibration.{default,tau,placeholder}
+selection_modules: columnflow.selection.empty, columnflow.selection.cms.{json_filter,met_filters}, hbt.selection.{default_custom,default,lepton,trigger}
 categorization_modules: hbt.categorization.default
 ml_modules: hbt.ml.test
-inference_modules: hbt.inference.test
+inference_modules: hbt.inference.{test,dl,base,derived,grav_model,test_unc}
 
 # namespace of all columnflow tasks
 cf_task_namespace: cf
@@ -134,7 +134,8 @@ webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/st
 gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
 base: &::webdav_base
-
+base_filecopy: &::xrootd_base
+base_stat: &::xrootd_base
 
 [wlcg_fs_desy_gsiftp]
 
@@ -183,6 +184,18 @@ cache_max_size: 15GB
 cache_global_lock: True
 cache_mtime_patience: -1
 
+[wlcg_fs_run2_2016_HIPM_nano_uhh_v12]
+
+base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/mrieger/nanogen_store/CreateNano/config_16pre_v12/prod2
+use_cache: $CF_WLCG_USE_CACHE
+cache_root: $CF_WLCG_CACHE_ROOT
+cache_cleanup: $CF_WLCG_CACHE_CLEANUP
+cache_max_size: 15GB
+cache_global_lock: True
+
+[local_fs_run2_2016_HIPM_nano_uhh_v12]
+
+base: file:///pnfs/desy.de/cms/tier2/store/user/mrieger/nanogen_store/CreateNano/config_16pre_v12/prod2
 
 [wlcg_fs_run2_2017_nano_uhh_v11]
 
@@ -198,6 +211,20 @@ cache_global_lock: True
 
 base: file:///pnfs/desy.de/cms/tier2/store/user/bwieders/nano_uhh_v11/merged_2048.0MB
 
+
+[wlcg_fs_run2_2016_nano_uhh_v12]
+
+base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/nprouvos/nano_uhh_v12/merged_2048.0MB
+use_cache: $CF_WLCG_USE_CACHE
+cache_root: $CF_WLCG_CACHE_ROOT
+cache_cleanup: $CF_WLCG_CACHE_CLEANUP
+cache_max_size: 15GB
+cache_global_lock: True
+
+
+[local_fs_run2_2016_nano_uhh_v12]
+
+base: file:///pnfs/desy.de/cms/tier2/store/user/nprouvos/nano_uhh_v12/merged_2048.0MB
 
 [wlcg_fs_desy_mrieger]
 
@@ -220,4 +247,11 @@ base: &::webdav_base
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
 gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
+base: &::webdav_base
+
+[wlcg_fs_desy_aalvesan]
+
+webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/aalvesan/hbt_store
+gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/aalvesan/hbt_store
+xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/aalvesan/hbt_store
 base: &::webdav_base

--- a/law.nocert.cfg
+++ b/law.nocert.cfg
@@ -1,0 +1,103 @@
+# law config file for running tasks without a grid certificate
+
+[core]
+
+# inherit from the analysis configuration file
+inherit: $HBT_BASE/law.cfg
+
+
+[local_desy_dcache]
+
+base: /pnfs/desy.de/cms/tier2
+
+
+
+[local_run2_2017_nano_uhh_v11_old]
+
+base: /pnfs/desy.de/cms/tier2/store/user/bwieders/nano_uhh_v11/merged_512.0MB
+
+[wlcg_fs_run2_2017_nano_uhh_v11_old]
+
+base: /pnfs/desy.de/cms/tier2/store/user/bwieders/nano_uhh_v11/merged_512.0MB
+use_cache: $CF_WLCG_USE_CACHE
+cache_root: $CF_WLCG_CACHE_ROOT
+cache_cleanup: $CF_WLCG_CACHE_CLEANUP
+cache_max_size: 15GB
+cache_global_lock: True
+cache_mtime_patience: -1
+
+[local_run2_2017_nano_uhh_v11]
+base: /pnfs/desy.de/cms/tier2/store/user/bwieders/nano_uhh_v11/merged_2048.0MB
+
+[wlcg_fs_run2_2017_nano_uhh_v11]
+
+base: /pnfs/desy.de/cms/tier2/store/user/bwieders/nano_uhh_v11/merged_2048.0MB
+use_cache: $CF_WLCG_USE_CACHE
+cache_root: $CF_WLCG_CACHE_ROOT
+cache_cleanup: $CF_WLCG_CACHE_CLEANUP
+cache_max_size: 15GB
+cache_global_lock: True
+cache_mtime_patience: -1
+
+[analysis]
+
+# whether or not the ensure_proxy decorator should be skipped, even if used by task's run methods
+skip_ensure_proxy: True
+#selection_modules: hbt.selection.{boosted,boosted_jet}
+#production_modules: hbt.production.{default,invariant_mass}
+
+[outputs]
+
+lfn_sources: local_desy_dcache
+
+
+# output locations per task family
+# for local targets : "local[, STORE_PATH]"
+# for remote targets: "wlcg[, WLCG_FS_NAME]"
+cf.BundleRepo: local
+cf.BundleSoftware: local
+cf.BundleBashSandbox: local
+cf.BundleCMSSWSandbox: local
+cf.BundleExternalFiles: local
+# GetDatasetLFNs requires a Grid certificate -> use a common space to store the output
+# cf.GetDatasetLFNs: local, /pnfs/desy.de/cms/tier2/store/user/nprouvos/hbt_store
+cf.GetDatasetLFNs: local, /pnfs/desy.de/cms/tier2/store/user/pkeicher/hbt_store
+cf.CalibrateEvents: local
+cf.SelectEvents: local
+cf.CreatePileupWeights: local, /pnfs/desy.de/cms/tier2/store/user/nprouvos/hbt_store
+cf.CreateCutflowHistograms: local
+cf.PlotCutflow: local
+cf.PlotCutflowVariables: local
+cf.ReduceEvents: local
+cf.MergeReducedEvents: local
+cf.ProduceColumns: local
+cf.PrepareMLEvents: local
+cf.MergeMLEvents: local
+cf.MLTraining: local
+cf.MLEvaluation: local
+cf.CreateHistograms: local
+cf.MergeHistograms: local
+cf.MergeShiftedHistograms: local
+cf.PlotVariables: local
+cf.PlotShiftedVariables: local
+cf.CreateDatacards: local
+cf.MergeReductionStats: local
+cf.MergeSelectionStats: local
+cf.MergeSelectionMasks: local
+
+
+[wlcg_fs]
+
+base: &::wlcg_fs_desy::base
+create_file_dir: True
+use_cache: $CF_WLCG_USE_CACHE
+cache_root: $CF_WLCG_CACHE_ROOT
+cache_cleanup: $CF_WLCG_CACHE_CLEANUP
+cache_max_size: 50GB
+
+
+[wlcg_fs_desy]
+
+xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
+gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
+base: &::gsiftp_base


### PR DESCRIPTION
* Initial commit

* Initial commit.

* Adapt to new order version.

* Add 2017 config and first set of processes.

* Fix process names.

* Add CI.

* Add lint file.

* Typo.

* Use own DotDict.

* Update README.md.

* Add QCD.

* Fix st dataset names.

* test adding hh2bbww processes and 2017 datasets

* restructuring of 2017 campaign

* lint

* Split processes.

* Added labels to hh2bbww processes and added docu for hh cross sections

* Add JEC era labels to datasets with type 'data'.

* Fix Tau era E sample.

* Add _nano_v9 postfix to current campaigns.

* Update tests.

* added first hh vbf datasets and processes

* update to HH inference naming conventions

* lint

* lint

* minor fix in HH vbf dataset names

* update W and DY cross sections

* Review comments.

* Add processes and samples for mttbar analysis.

* Add SinglePhoton dataset (UL17).

* Fill in cross sections for ZZ, WZ and WW.

* Add QCD cross sections.

* Add full link to ANs as reference for xsecs.

* Minor change to naming scheme from mttbar process/datasets.

* Generalize jec eras.

* Start uhh v11 nano campaign.

* Fix nano version in campaign aux entries.

* Use `era` for SinglePhoton to match other datasets.

* add lepton enriched qcd processes/datasets

* typo in das strings

* Add nano_v9 as main QCD samples. Keep existing v2 with suffix.

* add references

* added new (merged) samples to list

* Use `era` for SinglePhoton to match other datasets.

* Add nano_v9 as main QCD samples. Keep existing v2 with suffix.

* add lepton enriched qcd processes/datasets

* typo in das strings

* add references

* Update dataset ids.

* Update hh2bbtautau samples.

* Updated signal/data entries where merging finished

* added all entries, excluding single_electron E

* added more entries where events match DAS

* fix typo with one of the vbf processes

* corrections from old names with miniaod to nanoaod in hh2bbtautau

* updated cmsdb version for hh2bbtautau file

* revert own changes on files not to be commited

* update cf

* law config for users without grid proxy

* import changes of input selection stat dict

* added entries for background datasets. only missing 4 datasets

* added entry of DY{100To250,650ToInf,M-50} and ttHtoTauTau

* First set of review changes.

* Add data_e_e.

* Add 2018 UHH v11 campaign.

* Add missing processes.

* Add cross section refs.

* Correct phase spaces.

* Fix processes in v9 campaigns, add new campaigns to ci.

* [HH Resonant] Add v7 2017 samples

* [HH Resonant] Forgot to import Number

* [HH Resonant] Fix duplicate IDs

* [HHbbWW resonant] Harmonize processes ID

* correction wrong fatjet/subjet objects filter jet selection

* Add JMENano for 2018 data

* File to read DAS info

* Add usage info

* Add multiple arguments

* Add wildcard

* add 2018 datasets

* remove obsolete 2018 config

* add 2018 triggers

* WIP: added trigger information for 2018

* Add dijet and qcd ht for 2018

* Reset 2018 campaign

* Add JMEnano campaign

* fix data_jetht

* Empty line at the end

* rename das info script

* Update linter, fix linting rules in get_das_info script.

* Fix processes.

* adding 2018 triggers

* adding Ana user details

* adding hotfix

* update columnflow

* Add DL non-resonant samples

* [Nonresonant HHbbWW DL] Fix typos

* pull CF changes

* Adapt to CF changes

* update cf

* updated cmsdb version for hh2bbtautau file

* revert own changes on files not to be commited

* law config for users without grid proxy

* correction wrong fatjet/subjet objects filter jet selection

* merge with master

* revert own changes on files not to be commited

* fix bug in get_shifts definition

* include new modules in law config

* moved modules to global law config

* add new categorization modules

* removed custom modules added by mistake

removed the modules invariant_mass and skip_jecunc which were added by mistake

* adding 2016 pre VFP datasets

* updating cmsdb

* started to include 2016 HIMP campaign

* updated cmsdb version for hh2bbtautau file

* revert own changes on files not to be commited

* law config for users without grid proxy

* correction wrong fatjet/subjet objects filter jet selection

* updated cmsdb version for hh2bbtautau file

* revert own changes on files not to be commited

* merge with master

* revert own changes on files not to be commited

* fix bug in get_shifts definition

* include new modules in law config

* moved modules to global law config

* removed custom modules added by mistake

removed the modules invariant_mass and skip_jecunc which were added by mistake

* sync submodules with master

* add unlimited config for 2017

* final categorization definition

* remove obsolete campaign

* include empty producer - NOTE: this will not produce any weights, update the list of weights in config first

* add empty objects to runtime environment

* creating gloval env for VS code

* update cf

* Update cmsdb/campaigns/run2_2016_HIPM_uhh_v12/DY.py



* Update cmsdb/campaigns/run2_2016_HIPM_uhh_v12/hh2bbtautau.py



* Update cmsdb/campaigns/run2_2016_HIPM_uhh_v12/hh2bbtautau.py



* Update cmsdb/campaigns/run2_2016_HIPM_uhh_v12/hh2bbtautau.py



* Update cmsdb/campaigns/run2_2016_HIPM_uhh_v12/hh2bbtautau.py



* Update cmsdb/campaigns/run2_2016_HIPM_uhh_v12/TT.py



* Update cmsdb/campaigns/run2_2016_HIPM_uhh_v12/W.py



* Update cmsdb/campaigns/run2_2016_HIPM_uhh_v12/Z.py



* Update cmsdb/campaigns/run2_2016_HIPM_uhh_v12/Z.py



* fixing various typos

* updating cmsdb

* fixing campaigns import to 2016

* updating cmsdb 2016

* adding ZZZ cmsdb entry

* fixing typo and adding WWW cmsdb entry

* adding WWW cmsdb entry

* correcting sytanx errors in cmsdb

* correcting syntax on cmsdb again

* correcting syntax on ttbar entry

* correcting syntax on campaign import

* update cmsdb syntax

* adding nano_ to 2016 campaign name

* updating 2016 campaign configs

* updating .flake8

* updating lint_and_test.yaml

* adding empty selector

* including 2016 config, no triggers

* removing temporary backup folder in cmsdb

* initializing 2016 triggers

* adding empty calibrator

* adding 2016 triggers to config

* adding placeholder trigger values

* commenting out single triggers

* removing trigger comments

* initializing placeholder calibrator

* fixing lint errors

* fixing lint errors

* fixing lint errors

* fixing lint errors

* fixing lint errors

* creating single trigger columns

* creating single trigger columns

* creating single trigger columns

* adding single-trigger placeholder calibrator

* fixing trigger config

* adding inference model grav_model

* add placeholder calibrator

* adding variable

* updating

* linting

* adding di-higgs producer

* adding selection methods

* updating law.cfg

* linting

* linting

* linting

* linting

* adding pu_sf to external_files

* updating datacards labeling

* adding trigger decisions

* removing default calibrations

* updating

* addin di-BJet and diTau variables

* updating placeholder, selector and producer

* add python version file

* updating

* updating

* updating

* merge 2016 pre and post

* add single electron and muon triggers for 2016 pre

* Delete .python-version

* add 2016 campaign to workflow tests

* remove weird cmsdb stuff and cleanup branch

* small refactoring features.py

* correct paths 2016 pre and post and add jec_eras for data

* change config to restore weights, correct triggers

* remove vscode sandboxes

---------