### PR TITLE
Trigger fixes for 2022

### DIFF
--- a/hbt/config/triggers.py
+++ b/hbt/config/triggers.py
@@ -833,7 +833,7 @@ def add_triggers_2022(config: od.Config) -> None:
             legs=[
                 TriggerLeg(
                     pdg_id=13,
-                    min_pt=25.0,
+                    min_pt=26.0,
                     # filter names:
                     # hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08 (1mu + Iso)
                     trigger_bits=2 + 8,
@@ -893,7 +893,7 @@ def add_triggers_2022(config: od.Config) -> None:
             legs=[
                 TriggerLeg(
                     pdg_id=13,
-                    min_pt=21.0,
+                    min_pt=22.0,
                     # filter names:
                     # hltL3crIsoBigORMu18erTauXXer2p1L1f0L2f10QL3f20QL3trkIsoFiltered0p08
                     # hltHpsOverlapFilterIsoMu20LooseMuTauWPDeepTauPFTau27L1Seeded (OverlapFilter PFTau)
@@ -983,6 +983,48 @@ def add_triggers_2022(config: od.Config) -> None:
         #
         # vbf
         #
+        Trigger(
+            name="HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1",
+            id=603,
+            legs=[
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=25.0,
+                    # filter names:
+                    # (DeepTau + HPS + run 3 VBF+ditau)
+                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
+                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    trigger_bits=8 + 32 + 4096,
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=25.0,
+                    # filter names:
+                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
+                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    trigger_bits=8 + 32 + 4096,
+                ),
+                # # additional leg infos for vbf jets
+                # TriggerLeg(
+                #     min_pt=115.0,
+                #     # filter names:
+                #     # The filters are applied to the lepton
+                #     # Taking the loosest filter for the Jets with the pt cut
+                #     trigger_bits=1,
+                # ),
+                # TriggerLeg(
+                #     min_pt=40.0,
+                #     # filter names:
+                #     # The filters are applied to the lepton
+                #     trigger_bits=1,
+                # ),
+            ],
+            # applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data and config.has_tag("pre")),
+            tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
+        ),
+
         # currently disabled
         # Trigger(
         #     name="HLT_VBF_DoubleLooseChargedIsoPFTauHPS20_Trk1_eta2p1",
@@ -1021,48 +1063,6 @@ def add_triggers_2022(config: od.Config) -> None:
         #     applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc and config.has_tag("pre")),
         #     tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
         # ),
-
-        Trigger(
-            name="HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1",
-            id=603,
-            legs=[
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=25.0,
-                    # filter names:
-                    # (DeepTau + HPS + run 3 VBF+ditau)
-                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
-                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
-                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
-                    trigger_bits=8 + 32 + 4096,
-                ),
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=25.0,
-                    # filter names:
-                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
-                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
-                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
-                    trigger_bits=8 + 32 + 4096,
-                ),
-                # additional leg infos for vbf jets
-                TriggerLeg(  # TODO
-                    min_pt=115.0,
-                    # filter names:
-                    # The filters are applied to the lepton
-                    # Taking the loosest filter for the Jets with the pt cut
-                    trigger_bits=1,
-                ),
-                TriggerLeg(
-                    min_pt=40.0,
-                    # filter names:
-                    # The filters are applied to the lepton
-                    trigger_bits=1,
-                ),
-            ],
-            # applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data and config.has_tag("pre")),
-            tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
-        ),
 
         # Currently disabled since it may not be needed
         # Trigger(
@@ -1105,13 +1105,13 @@ def add_triggers_2022(config: od.Config) -> None:
                     # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet
                     trigger_bits=16 + 16384,
                 ),
-                TriggerLeg(
-                    min_pt=65.0,
-                    # filter names:
-                    # Filters are applied to the leptons
-                    # Taking the loosest filter for the Jets with the pt cut
-                    trigger_bits=1,
-                ),
+                # TriggerLeg(
+                #     min_pt=65.0,
+                #     # filter names:
+                #     # Filters are applied to the leptons
+                #     # Taking the loosest filter for the Jets with the pt cut
+                #     trigger_bits=1,
+                # ),
             ],
             tags={"cross_trigger", "cross_tau_tau_jet", "channel_tau_tau"},
         ),
@@ -1160,26 +1160,12 @@ def add_triggers_2023(config: od.Config) -> None:
         # single electron
         #
         Trigger(
-            name="HLT_Ele32_WPTight_Gsf",
+            name="HLT_Ele30_WPTight_Gsf",
             id=201,
             legs=[
                 TriggerLeg(
                     pdg_id=11,
-                    min_pt=33.0,
-                    # filter names:
-                    # WPTightTrackIso
-                    trigger_bits=2,
-                ),
-            ],
-            tags={"single_trigger", "single_e", "channel_e_tau"},
-        ),
-        Trigger(
-            name="HLT_Ele35_WPTight_Gsf",
-            id=203,
-            legs=[
-                TriggerLeg(
-                    pdg_id=11,
-                    min_pt=36.0,
+                    min_pt=31.0,
                     # filter names:
                     # WPTightTrackIso
                     trigger_bits=2,
@@ -1199,21 +1185,7 @@ def add_triggers_2023(config: od.Config) -> None:
                     pdg_id=13,
                     min_pt=25.0,
                     # filter names:
-                    # "Iso", "SingleMuon"
-                    trigger_bits=2 + 8,
-                ),
-            ],
-            tags={"single_trigger", "single_mu", "channel_mu_tau"},
-        ),
-        Trigger(
-            name="HLT_IsoMu27",
-            id=102,
-            legs=[
-                TriggerLeg(
-                    pdg_id=13,
-                    min_pt=28.0,
-                    # filter names:
-                    # "Iso", "SingleMuon"
+                    # hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08 (1mu + Iso)
                     trigger_bits=2 + 8,
                 ),
             ],
@@ -1231,14 +1203,16 @@ def add_triggers_2023(config: od.Config) -> None:
                     pdg_id=11,
                     min_pt=25.0,
                     # filter names:
-                    # OverlapFilterPFTau
+                    # hltEle24erWPTightGsfTrackIsoFilterForTau
+                    # hltHpsOverlapFilterIsoEle24WPTightGsfLooseETauWPDeepTauPFTau30 (OverlapFilter)
                     trigger_bits=8,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # "DeepTau", "Hps"
+                    # hltHpsSelectedPFTau30LooseETauWPDeepTauL1HLTMatched (DeepTau + HPS)
+                    # hltHpsOverlapFilterIsoEle24WPTightGsfLooseETauWPDeepTauPFTau30
                     trigger_bits=8 + 32,
                 ),
             ],
@@ -1256,16 +1230,16 @@ def add_triggers_2023(config: od.Config) -> None:
                     pdg_id=13,
                     min_pt=21.0,
                     # filter names:
-                    # hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07
-                    # hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded
+                    # hltL3crIsoBigORMu18erTauXXer2p1L1f0L2f10QL3f20QL3trkIsoFiltered0p08
+                    # hltHpsOverlapFilterIsoMu20LooseMuTauWPDeepTauPFTau27L1Seeded (OverlapFilter PFTau)
                     trigger_bits=4,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=32.0,
                     # filter names:
-                    # hltSelectedPFTau27LooseChargedIsolationAgainstMuonL1HLTMatched or
-                    # hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded
+                    # hltHpsSelectedPFTau27LooseMuTauWPDeepTauVsJetsAgainstMuonL1HLTMatched (DeepTau + HPS)
+                    # hltHpsOverlapFilterIsoMu20LooseMuTauWPDeepTauPFTau27L1Seeded
                     trigger_bits=8 + 32,
                 ),
             ],
@@ -1283,18 +1257,49 @@ def add_triggers_2023(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=40.0,
                     # filter names:
-                    # "TightOOSCPhotons", "DiTauAndPFJet"
-                    trigger_bits=16 + 16384,
+                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (Deeptau + HPS)
+                    trigger_bits=8 + 32,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=40.0,
                     # filter names:
-                    # "TightOOSCPhotons", "DiTauAndPFJet"
-                    trigger_bits=16 + 16384,
+                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (Deeptau + HPS)
+                    trigger_bits=8 + 32,
                 ),
             ],
             tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
+        ),
+
+        #
+        # vbf
+        #
+        Trigger(
+            name="HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1",
+            id=603,
+            legs=[
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=25.0,
+                    # filter names:
+                    # (DeepTau + HPS + run 3 VBF+ditau)
+                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
+                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    trigger_bits=8 + 32 + 4096,
+                ),
+                TriggerLeg(
+                    pdg_id=15,
+                    min_pt=25.0,
+                    # filter names:
+                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
+                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    trigger_bits=8 + 32 + 4096,
+                ),
+            ],
+            # applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data and config.has_tag("pre")),
+            tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
         ),
 
         #
@@ -1308,62 +1313,18 @@ def add_triggers_2023(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # "TightOOSCPhotons", "DiTauAndPFJet
+                    # (TightOOSCPhotons + di-tau + PFJet)
+                    # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet
                     trigger_bits=16 + 16384,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # "TightOOSCPhotons", "DiTauAndPFJet
+                    # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet
                     trigger_bits=16 + 16384,
-                ),
-                TriggerLeg(
-                    min_pt=65.0,
-                    # filter names:
-                    # hltMatchedDoubleTau35OnePFJet60CrossCleaned
-                    trigger_bits=1,
                 ),
             ],
             tags={"cross_trigger", "cross_tau_tau_jet", "channel_tau_tau"},
-        ),
-
-        #
-        # vbf
-        #
-        Trigger(
-            name="HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1",
-            id=602,
-            legs=[
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=25.0,
-                    # filter names:
-                    # LooseChargedIso", "Hps", "VBFpDoublePFTau_run3"
-                    trigger_bits=1 + 32 + 4096,
-                ),
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=25.0,
-                    # filter names:
-                    # LooseChargedIso", "Hps", "VBFpDoublePFTau_run3"
-                    trigger_bits=1 + 32 + 4096,
-                ),
-                # additional leg infos for vbf jets
-                TriggerLeg(  # TODO
-                    min_pt=115.0,
-                    # filter names:
-                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20
-                    trigger_bits=1,
-                ),
-                TriggerLeg(
-                    min_pt=40.0,
-                    # filter names:
-                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleLooseChargedIsoPFTau20
-                    trigger_bits=1,
-                ),
-            ],
-            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc),
-            tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
         ),
     ])

--- a/hbt/config/triggers.py
+++ b/hbt/config/triggers.py
@@ -529,6 +529,7 @@ def add_triggers_2017(config: od.Config) -> None:
                     trigger_bits=2048,
                 ),
                 # additional leg infos for vbf jets
+                # TODO check if vbf legs are needed
                 TriggerLeg(
                     min_pt=115.0,
                     # filter names:
@@ -794,12 +795,12 @@ def add_triggers_2022(config: od.Config) -> None:
         # single electron
         #
         Trigger(
-            name="HLT_Ele32_WPTight_Gsf",
+            name="HLT_Ele30_WPTight_Gsf",
             id=201,
             legs=[
                 TriggerLeg(
                     pdg_id=11,
-                    min_pt=33.0,
+                    min_pt=30.0,
                     # filter names:
                     # WPTightTrackIso
                     trigger_bits=2,
@@ -807,20 +808,21 @@ def add_triggers_2022(config: od.Config) -> None:
             ],
             tags={"single_trigger", "single_e", "channel_e_tau"},
         ),
-        Trigger(
-            name="HLT_Ele35_WPTight_Gsf",
-            id=203,
-            legs=[
-                TriggerLeg(
-                    pdg_id=11,
-                    min_pt=36.0,
-                    # filter names:
-                    # WPTightTrackIso
-                    trigger_bits=2,
-                ),
-            ],
-            tags={"single_trigger", "single_e", "channel_e_tau"},
-        ),
+        # Currently disabled
+        # Trigger(
+        #     name="HLT_Ele35_WPTight_Gsf",
+        #     id=203,
+        #     legs=[
+        #         TriggerLeg(
+        #             pdg_id=11,
+        #             min_pt=36.0,
+        #             # filter names:
+        #             # hltEle35noerWPTightGsfTrackIsoFilter (Single e WPTight)
+        #             trigger_bits=2,
+        #         ),
+        #     ],
+        #     tags={"single_trigger", "single_e", "channel_e_tau"},
+        # ),
 
         #
         # single muon
@@ -833,26 +835,27 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=13,
                     min_pt=25.0,
                     # filter names:
-                    # "Iso", "SingleMuon"
+                    # hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08 (1mu + Iso)
                     trigger_bits=2 + 8,
                 ),
             ],
             tags={"single_trigger", "single_mu", "channel_mu_tau"},
         ),
-        Trigger(
-            name="HLT_IsoMu27",
-            id=102,
-            legs=[
-                TriggerLeg(
-                    pdg_id=13,
-                    min_pt=28.0,
-                    # filter names:
-                    # "Iso", "SingleMuon"
-                    trigger_bits=2 + 8,
-                ),
-            ],
-            tags={"single_trigger", "single_mu", "channel_mu_tau"},
-        ),
+        # Currently disabled
+        # Trigger(
+        #     name="HLT_IsoMu27",
+        #     id=102,
+        #     legs=[
+        #         TriggerLeg(
+        #             pdg_id=13,
+        #             min_pt=28.0,
+        #             # filter names:
+        #             # hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p08 (1mu + Iso)
+        #             trigger_bits=2 + 8,
+        #         ),
+        #     ],
+        #     tags={"single_trigger", "single_mu", "channel_mu_tau"},
+        # ),
 
         #
         # e tauh
@@ -865,14 +868,16 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=11,
                     min_pt=25.0,
                     # filter names:
-                    # OverlapFilterPFTau
+                    # hltEle24erWPTightGsfTrackIsoFilterForTau
+                    # hltHpsOverlapFilterIsoEle24WPTightGsfLooseETauWPDeepTauPFTau30 (OverlapFilter)
                     trigger_bits=8,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # "DeepTau", "Hps"
+                    # hltHpsSelectedPFTau30LooseETauWPDeepTauL1HLTMatched (DeepTau + HPS)
+                    # hltHpsOverlapFilterIsoEle24WPTightGsfLooseETauWPDeepTauPFTau30
                     trigger_bits=8 + 32,
                 ),
             ],
@@ -890,16 +895,16 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=13,
                     min_pt=21.0,
                     # filter names:
-                    # hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07
-                    # hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded
+                    # hltL3crIsoBigORMu18erTauXXer2p1L1f0L2f10QL3f20QL3trkIsoFiltered0p08
+                    # hltHpsOverlapFilterIsoMu20LooseMuTauWPDeepTauPFTau27L1Seeded (OverlapFilter PFTau)
                     trigger_bits=4,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=32.0,
                     # filter names:
-                    # hltSelectedPFTau27LooseChargedIsolationAgainstMuonL1HLTMatched or
-                    # hltOverlapFilterIsoMu20LooseChargedIsoPFTau27L1Seeded
+                    # hltHpsSelectedPFTau27LooseMuTauWPDeepTauVsJetsAgainstMuonL1HLTMatched (DeepTau + HPS)
+                    # hltHpsOverlapFilterIsoMu20LooseMuTauWPDeepTauPFTau27L1Seeded
                     trigger_bits=8 + 32,
                 ),
             ],
@@ -917,103 +922,105 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=40.0,
                     # filter names:
-                    # hltDoublePFTau35TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg
+                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (deeptau + HPS)
                     trigger_bits=8 + 32,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=40.0,
                     # filter names:
-                    # hltDoublePFTau35TrackPt1MediumChargedIsolationAndTightOOSCPhotonsDz02Reg
+                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (deeptau + HPS)
                     trigger_bits=8 + 32,
                 ),
             ],
             tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
         ),
-        Trigger(
-            name="HLT_DoubleMediumChargedIsoPFTauHPS40_Trk1_eta2p1",
-            id=506,
-            legs=[
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=45.0,
-                    # filter names:
-                    # "MediumChargedIso", "Hps", "TightOOSCPhotons"
-                    trigger_bits=2 + 32 + 16,
-                ),
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=45.0,
-                    # filter names:
-                    # "MediumChargedIso", "Hps", "TightOOSCPhotons"
-                    trigger_bits=2 + 32 + 16,
-                ),
-            ],
-            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc or dataset_inst.x.era >= "E"),
-            tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
-        ),
+        # Currently disabled
+        # Trigger(
+        #     name="HLT_DoubleMediumChargedIsoPFTauHPS40_Trk1_eta2p1",
+        #     id=506,
+        #     legs=[
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=45.0,
+        #             # filter names:
+        #             trigger_bits=2 + 32 + 64,
+        #         ),
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=45.0,
+        #             # filter names:
+        #             trigger_bits=2 + 32 + 64,
+        #         ),
+        #     ],
+        #     applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc or dataset_inst.x.era >= "E"),
+        #     tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
+        # ),
 
-        Trigger(
-            name="HLT_DoubleMediumChargedIsoDisplacedPFTauHPS32_Trk1_eta2p1",
-            id=507,
-            legs=[
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=45.0,
-                    # filter names:
-                    # "MediumChargedIso", "Hps", "TightOOSCPhotons"
-                    trigger_bits=2 + 32 + 16,
-                ),
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=45.0,
-                    # filter names:
-                    # "MediumChargedIso", "Hps", "TightOOSCPhotons"
-                    trigger_bits=2 + 32 + 16,
-                ),
-            ],
-            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data and dataset_inst.x.era < "E"),
-            tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
-        ),
+        # Trigger(
+        #     name="HLT_DoubleMediumChargedIsoDisplacedPFTauHPS32_Trk1_eta2p1",
+        #     id=507,
+        #     legs=[
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=45.0,
+        #             # filter names:
+        #             # hltHpsDoubleMediumChargedIsoDisplPFTau32Dxy0p005
+        #             trigger_bits=2 + 32 + 64 + 32768,
+        #         ),
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=45.0,
+        #             # filter names:
+        #             # hltHpsDoubleMediumChargedIsoDisplPFTau32Dxy0p005
+        #             trigger_bits=2 + 32 + 64 + 32768,
+        #         ),
+        #     ],
+        #     applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data and dataset_inst.x.era < "E"),
+        #     tags={"cross_trigger", "cross_tau_tau", "channel_tau_tau"},
+        # ),
 
         #
         # vbf
         #
-        Trigger(
-            name="HLT_VBF_DoubleLooseChargedIsoPFTauHPS20_Trk1_eta2p1",
-            id=602,
-            legs=[
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=25.0,
-                    # filter names:
-                    # LooseChargedIso", "Hps", "VBFpDoublePFTau_run3"
-                    trigger_bits=1 + 32 + 4096,
-                ),
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=25.0,
-                    # filter names:
-                    # LooseChargedIso", "Hps", "VBFpDoublePFTau_run3"
-                    trigger_bits=1 + 32 + 4096,
-                ),
-                # additional leg infos for vbf jets
-                TriggerLeg(  # TODO
-                    min_pt=115.0,
-                    # filter names:
-                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20
-                    trigger_bits=1,
-                ),
-                TriggerLeg(
-                    min_pt=40.0,
-                    # filter names:
-                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleLooseChargedIsoPFTau20
-                    trigger_bits=1,
-                ),
-            ],
-            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc and config.has_tag("pre")),
-            tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
-        ),
+        # currently disabled
+        # Trigger(
+        #     name="HLT_VBF_DoubleLooseChargedIsoPFTauHPS20_Trk1_eta2p1",
+        #     id=602,
+        #     legs=[
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=25.0,
+        #             # filter names:
+        #             # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTauHPS20 (LooseChargedIso + HPS + run 3 VBF+ditau) # noqa
+        #             # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleLooseChargedIsoPFTauHPS20
+        #             # hltHpsDoublePFTau20TrackLooseChargedIso
+        #             trigger_bits=1 + 32 + 4096,
+        #         ),
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=25.0,
+        #             # filter names:
+        #             # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTauHPS20 (LooseChargedIso + HPS + run 3 VBF+ditau)  # noqa
+        #             # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleLooseChargedIsoPFTauHPS20
+        #             # hltHpsDoublePFTau20TrackLooseChargedIso
+        #             trigger_bits=1 + 32 + 4096,
+        #         ),
+        #         # additional leg infos for vbf jets
+        #         TriggerLeg(  # TODO
+        #             min_pt=115.0,
+        #             # filter names:
+        #             trigger_bits=None,
+        #         ),
+        #         TriggerLeg(
+        #             min_pt=40.0,
+        #             # filter names:
+        #             trigger_bits=None,
+        #         ),
+        #     ],
+        #     applies_to_dataset=(lambda dataset_inst: dataset_inst.is_mc and config.has_tag("pre")),
+        #     tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
+        # ),
 
         Trigger(
             name="HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1",
@@ -1023,33 +1030,36 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=25.0,
                     # filter names:
-                    # LooseChargedIso", "Hps", "VBFpDoublePFTau_run3"
-                    trigger_bits=1 + 32 + 4096,
+                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau (DeepTau + HPS + run 3 VBF+ditau)
+                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    trigger_bits=8 + 32 + 4096,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=25.0,
                     # filter names:
-                    # LooseChargedIso", "Hps", "VBFpDoublePFTau_run3"
-                    trigger_bits=1 + 32 + 4096,
+                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
+                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
+                    trigger_bits=8 + 32 + 4096,
                 ),
                 # additional leg infos for vbf jets
                 TriggerLeg(  # TODO
                     min_pt=115.0,
                     # filter names:
-                    # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleLooseChargedIsoPFTau20
-                    trigger_bits=1,
+                    trigger_bits=None,
                 ),
                 TriggerLeg(
                     min_pt=40.0,
                     # filter names:
-                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleLooseChargedIsoPFTau20
-                    trigger_bits=1,
+                    trigger_bits=None,
                 ),
             ],
-            applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data and config.has_tag("pre")),
+            # applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data and config.has_tag("pre")),
             tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
         ),
+
         #
         # tau tau jet
         #
@@ -1061,52 +1071,57 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # "TightOOSCPhotons", "DiTauAndPFJet"
+                    # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet (Deeptau + HPS + di-tau + PFJet)
                     trigger_bits=16 + 16384,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # "TightOOSCPhotons", "DiTauAndPFJet"
+                    # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet
                     trigger_bits=16 + 16384,
                 ),
                 TriggerLeg(
                     min_pt=65.0,
                     # filter names:
-                    # hltMatchedDoubleTau35OnePFJet60CrossCleaned
-                    trigger_bits=1,
+                    # hlt1PFJet60L1HLTMatched
+                    trigger_bits=None,
                 ),
             ],
             tags={"cross_trigger", "cross_tau_tau_jet", "channel_tau_tau"},
         ),
-        Trigger(
-            name="HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet75",
-            id=702,
-            legs=[
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=35.0,
-                    # filter names:
-                    # TightOOSCPhotons", "DiTauAndPFJet
-                    trigger_bits=16 + 16384,
-                ),
-                TriggerLeg(
-                    pdg_id=15,
-                    min_pt=35.0,
-                    # filter names:
-                    # TightOOSCPhotons", "DiTauAndPFJet
-                    trigger_bits=16 + 16384,
-                ),
-                TriggerLeg(
-                    min_pt=80.0,
-                    # filter names:
-                    # hltMatchedDoubleTau35OnePFJet75CrossCleaned
-                    trigger_bits=1,
-                ),
-            ],
-            tags={"cross_trigger", "cross_tau_tau_jet", "channel_tau_tau"},
-        ),
+        # Currently disabled
+        # Trigger(
+        #     name="HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet75",
+        #     id=702,
+        #     legs=[
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=35.0,
+        #             # filter names:
+        #             # hltHpsOverlapFilterDeepTauDoublePFTau30PFJet75 (Deeptau + HPS + di-tau + PFJet)
+        #             # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet
+        #             # hlt1PFJet75L1HLTMatched
+        #             trigger_bits=8 + 32 + 16384,
+        #         ),
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=35.0,
+        #             # filter names:
+        #             # hltHpsOverlapFilterDeepTauDoublePFTau30PFJet75
+        #             # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet
+        #             # hlt1PFJet75L1HLTMatched
+        #             trigger_bits=8 + 32 + 16384,
+        #         ),
+        #         TriggerLeg(
+        #             min_pt=75.0,
+        #             # filter names:
+        #             # hltHpsOverlapFilterDeepTauDoublePFTau30PFJet75
+        #             trigger_bits=None,
+        #         ),
+        #     ],
+        #     tags={"cross_trigger", "cross_tau_tau_jet", "channel_tau_tau"},
+        # ),
     ])
 
 

--- a/hbt/config/triggers.py
+++ b/hbt/config/triggers.py
@@ -1050,13 +1050,14 @@ def add_triggers_2022(config: od.Config) -> None:
                     min_pt=115.0,
                     # filter names:
                     # The filters are applied to the lepton
-                    trigger_bits=None,
+                    # Taking the loosest filter for the Jets with the pt cut
+                    trigger_bits=1,
                 ),
                 TriggerLeg(
                     min_pt=40.0,
                     # filter names:
                     # The filters are applied to the lepton
-                    trigger_bits=None,
+                    trigger_bits=1,
                 ),
             ],
             # applies_to_dataset=(lambda dataset_inst: dataset_inst.is_data and config.has_tag("pre")),
@@ -1089,7 +1090,8 @@ def add_triggers_2022(config: od.Config) -> None:
                     min_pt=65.0,
                     # filter names:
                     # Filters are applied to the leptons
-                    trigger_bits=None,
+                    # Taking the loosest filter for the Jets with the pt cut
+                    trigger_bits=1,
                 ),
             ],
             tags={"cross_trigger", "cross_tau_tau_jet", "channel_tau_tau"},

--- a/hbt/config/triggers.py
+++ b/hbt/config/triggers.py
@@ -800,7 +800,7 @@ def add_triggers_2022(config: od.Config) -> None:
             legs=[
                 TriggerLeg(
                     pdg_id=11,
-                    min_pt=30.0,
+                    min_pt=31.0,
                     # filter names:
                     # WPTightTrackIso
                     trigger_bits=2,

--- a/hbt/config/triggers.py
+++ b/hbt/config/triggers.py
@@ -1064,6 +1064,25 @@ def add_triggers_2022(config: od.Config) -> None:
             tags={"cross_trigger", "cross_tau_tau_vbf", "channel_tau_tau"},
         ),
 
+        # Currently disabled since it may not be needed
+        # Trigger(
+        #     name="HLT_DoublePFJets40_Mass500_MediumDeepTauPFTauHPS45_L2NN_MediumDeepTauPFTauHPS20_eta2p1",
+        #     id=604,
+        #     legs=[
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=25.0,
+        #             trigger_bits=None,
+        #         ),
+        #         TriggerLeg(
+        #             pdg_id=15,
+        #             min_pt=25.0,
+        #             # filter names:
+        #             trigger_bits=None,
+        #         )
+        #     ],
+        # )
+
         #
         # tau tau jet
         #

--- a/hbt/config/triggers.py
+++ b/hbt/config/triggers.py
@@ -789,6 +789,9 @@ def add_triggers_2022(config: od.Config) -> None:
     """
     Adds all triggers to a *config*. For the conversion from filter names to trigger bits, see
     https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/triggerObjects_cff.py.
+    Tau Trigger: https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauTrigger#Trigger_Table_for_2022
+    Electron Trigger: https://twiki.cern.ch/twiki/bin/view/CMS/EgHLTRunIIISummary
+    Muon Trigger: https://twiki.cern.ch/twiki/bin/view/CMS/MuonHLT2022
     """
     config.x.triggers = od.UniqueObjectIndex(Trigger, [
         #
@@ -802,7 +805,7 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=11,
                     min_pt=31.0,
                     # filter names:
-                    # WPTightTrackIso
+                    # hltEle30WPTightGsfTrackIsoFilter
                     trigger_bits=2,
                 ),
             ],
@@ -868,15 +871,15 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=11,
                     min_pt=25.0,
                     # filter names:
-                    # hltEle24erWPTightGsfTrackIsoFilterForTau
-                    # hltHpsOverlapFilterIsoEle24WPTightGsfLooseETauWPDeepTauPFTau30 (OverlapFilter)
+                    # hltOverlapFilterIsoEle24IsoTau30WPTightGsfCaloJet5 # TODO Twiki has no matches
+                    # hltHpsOverlapFilterIsoEle24WPTightGsfLooseETauWPDeepTauPFTau30 (OverlapFilter) # TODO Twiki sugests 8 + 64  # noqa
                     trigger_bits=8,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # hltHpsSelectedPFTau30LooseETauWPDeepTauL1HLTMatched (DeepTau + HPS)
+                    # (DeepTau + HPS) # TODO Twiki sugests 8 + 32 + 256
                     # hltHpsOverlapFilterIsoEle24WPTightGsfLooseETauWPDeepTauPFTau30
                     trigger_bits=8 + 32,
                 ),
@@ -895,15 +898,15 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=13,
                     min_pt=22.0,
                     # filter names:
-                    # hltL3crIsoBigORMu18erTauXXer2p1L1f0L2f10QL3f20QL3trkIsoFiltered0p08
-                    # hltHpsOverlapFilterIsoMu20LooseMuTauWPDeepTauPFTau27L1Seeded (OverlapFilter PFTau)
+                    # hltL3crIsoBigORMu18erTauXXer2p1L1f0L2f10QL3f20QL3trkIsoFiltered  # TODO Twiki sugests 2
+                    # hltHpsOverlapFilterIsoMu20LooseMuTauWPDeepTauPFTau27L1Seeded (OverlapFilter PFTau) # TODO Twiki sugests 4 + 64  # noqa
                     trigger_bits=4,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=32.0,
                     # filter names:
-                    # hltHpsSelectedPFTau27LooseMuTauWPDeepTauVsJetsAgainstMuonL1HLTMatched (DeepTau + HPS)
+                    # (DeepTau + HPS) # TODO Twiki sugests 8 + 32 + 512 + 262144
                     # hltHpsOverlapFilterIsoMu20LooseMuTauWPDeepTauPFTau27L1Seeded
                     trigger_bits=8 + 32,
                 ),
@@ -922,14 +925,14 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=40.0,
                     # filter names:
-                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (Deeptau + HPS)
+                    # hltHpsDoublePFTau35MediumDitauWPDeepTauDz02 (Deeptau + HPS)
                     trigger_bits=8 + 32,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=40.0,
                     # filter names:
-                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (Deeptau + HPS)
+                    # hltHpsDoublePFTau35MediumDitauWPDeepTauDz02 (Deeptau + HPS)
                     trigger_bits=8 + 32,
                 ),
             ],
@@ -991,19 +994,15 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=25.0,
                     # filter names:
-                    # (DeepTau + HPS + run 3 VBF+ditau)
-                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
+                    # (DeepTau + HPS + run 3 VBF+ditau) # TODO Twiki sugests 8
                     # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
-                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
                     trigger_bits=8 + 32 + 4096,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=25.0,
                     # filter names:
-                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
                     # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
-                    # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
                     trigger_bits=8 + 32 + 4096,
                 ),
                 # # additional leg infos for vbf jets
@@ -1094,15 +1093,15 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # (TightOOSCPhotons + di-tau + PFJet)
-                    # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet
+                    # (TightOOSCPhotons + di-tau + PFJet) # TODO Twiki sugests 8 + 32 + 16384
+                    # hltHpsOverlapFilterDeepTauDoublePFTau30PFJet60
                     trigger_bits=16 + 16384,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet
+                    # hltHpsOverlapFilterDeepTauDoublePFTau30PFJet60
                     trigger_bits=16 + 16384,
                 ),
                 # TriggerLeg(

--- a/hbt/config/triggers.py
+++ b/hbt/config/triggers.py
@@ -922,14 +922,14 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=40.0,
                     # filter names:
-                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (deeptau + HPS)
+                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (Deeptau + HPS)
                     trigger_bits=8 + 32,
                 ),
                 TriggerLeg(
                     pdg_id=15,
                     min_pt=40.0,
                     # filter names:
-                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (deeptau + HPS)
+                    # hltHpsDoublePFTau35MediumDitauWPDeepTauL1HLTMatched (Deeptau + HPS)
                     trigger_bits=8 + 32,
                 ),
             ],
@@ -1030,7 +1030,8 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=25.0,
                     # filter names:
-                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau (DeepTau + HPS + run 3 VBF+ditau)
+                    # (DeepTau + HPS + run 3 VBF+ditau)
+                    # hltHpsDoublePFTau20TrackDeepTauDitauWPForVBFIsoTau
                     # hltMatchedVBFOnePFJet2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
                     # hltMatchedVBFTwoPFJets2CrossCleanedFromDoubleMediumDeepTauDitauWPPFTauHPS20
                     trigger_bits=8 + 32 + 4096,
@@ -1048,11 +1049,13 @@ def add_triggers_2022(config: od.Config) -> None:
                 TriggerLeg(  # TODO
                     min_pt=115.0,
                     # filter names:
+                    # The filters are applied to the lepton
                     trigger_bits=None,
                 ),
                 TriggerLeg(
                     min_pt=40.0,
                     # filter names:
+                    # The filters are applied to the lepton
                     trigger_bits=None,
                 ),
             ],
@@ -1071,7 +1074,8 @@ def add_triggers_2022(config: od.Config) -> None:
                     pdg_id=15,
                     min_pt=35.0,
                     # filter names:
-                    # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet (Deeptau + HPS + di-tau + PFJet)
+                    # (TightOOSCPhotons + di-tau + PFJet)
+                    # hltHpsDoublePFTau30MediumDitauWPDeepTauL1HLTMatchedDoubleTauJet
                     trigger_bits=16 + 16384,
                 ),
                 TriggerLeg(
@@ -1084,7 +1088,7 @@ def add_triggers_2022(config: od.Config) -> None:
                 TriggerLeg(
                     min_pt=65.0,
                     # filter names:
-                    # hlt1PFJet60L1HLTMatched
+                    # Filters are applied to the leptons
                     trigger_bits=None,
                 ),
             ],

--- a/hbt/selection/lepton.py
+++ b/hbt/selection/lepton.py
@@ -476,7 +476,7 @@ def lepton_selection(
             sel_muon_indices = ak.where(where, muon_indices, sel_muon_indices)
             sel_tau_indices = ak.where(where, tau_indices, sel_tau_indices)
 
-        elif trigger.has_tag({"cross_tau_tau", "cross_tau_tau_vbf"}):
+        elif trigger.has_tag({"cross_tau_tau", "cross_tau_tau_vbf", "cross_tau_tau_jet"}):
             # expect 0 veto electrons, 0 veto muons and at least two taus of which one is isolated
             is_tautau = (
                 trigger_fired &

--- a/hbt/tasks/studies/triggers.py
+++ b/hbt/tasks/studies/triggers.py
@@ -7,6 +7,7 @@ Trigger relatad studies.
 from collections import OrderedDict
 
 import law
+import luigi
 
 from columnflow.tasks.framework.base import Requirements, DatasetTask
 from columnflow.tasks.framework.mixins import DatasetsProcessesMixin
@@ -17,7 +18,28 @@ from hbt.tasks.base import HBTTask
 from hbt.tasks.parameters import table_format_param, escape_markdown_param
 
 
-class PrintTriggersInFile(HBTTask, DatasetTask, law.tasks.RunOnceTask):
+logger = law.logger.get_logger(__name__)
+
+
+class HBTTriggerTask(HBTTask):
+    """
+    Base task for trigger related studies.
+    """
+
+    sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
+
+    version = None
+
+    lfn_indices = law.CSVParameter(
+        cls=luigi.IntParameter,
+        default=0,
+        description="Indices of the LFN to use in the dataset. Defaults to 0.",
+        significant=False,
+        force_tuple=True,
+    )
+
+
+class PrintTriggersInFile(HBTTriggerTask, DatasetTask, law.tasks.RunOnceTask):
     """
     Prints a list of all HLT paths contained in the first file of a dataset.
 
@@ -25,10 +47,6 @@ class PrintTriggersInFile(HBTTask, DatasetTask, law.tasks.RunOnceTask):
 
         > law run hbt.PrintTriggersInFile --dataset hh_ggf_bbtautau_madgraph
     """
-
-    sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
-
-    version = None
 
     # upstream requirements
     reqs = Requirements(
@@ -42,8 +60,14 @@ class PrintTriggersInFile(HBTTask, DatasetTask, law.tasks.RunOnceTask):
     @ensure_proxy
     @law.tasks.RunOnceTask.complete_on_success
     def run(self):
+        # get LFN index from the parameter
+        if len(self.lfn_indices) != 1:
+            logger.warning("multiple LFN indices are not supported in this task, using the first one")
+        lfn_index = self.lfn_indices[0]
+        logger.info(f"Printing HLT paths for LFN index {lfn_index}")
+
         # prepare input
-        input_file = list(self.requires().iter_nano_files(self, lfn_indices=[0]))[0][1]
+        input_file = list(self.requires().iter_nano_files(self, lfn_indices=[lfn_index]))[0][1]
 
         # open with uproot
         with self.publish_step("load and open ..."):
@@ -61,7 +85,7 @@ class PrintTriggersInFile(HBTTask, DatasetTask, law.tasks.RunOnceTask):
         print("")
 
 
-class PrintExistingConfigTriggers(HBTTask, DatasetsProcessesMixin, law.tasks.RunOnceTask):
+class PrintExistingConfigTriggers(HBTTriggerTask, DatasetsProcessesMixin, law.tasks.RunOnceTask):
     """
     Prints a table showing datasets (one per column) and contained HLT paths (one per row).
 
@@ -73,9 +97,6 @@ class PrintExistingConfigTriggers(HBTTask, DatasetsProcessesMixin, law.tasks.Run
     table_format = table_format_param
     escape_markdown = escape_markdown_param
 
-    sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
-
-    version = None
     processes = None
     allow_empty_processes = True
 
@@ -102,24 +123,28 @@ class PrintExistingConfigTriggers(HBTTask, DatasetsProcessesMixin, law.tasks.Run
         header = ["HLT path"]
         rows = [[fmt(trigger.hlt_field)] for trigger in self.config_inst.x.triggers]
 
+        lfn_indices = list(set(self.lfn_indices))
+        logger.info(f"Printing HLT paths for LFN indices: {lfn_indices}")
+
         for dataset, lfn_task in self.requires().items():
             # prepare input
-            input_file = list(lfn_task.iter_nano_files(self, lfn_indices=[0]))[0][1]
+            for input_file in list(lfn_task.iter_nano_files(self, lfn_indices=lfn_indices)):
 
-            # open with uproot
-            with self.publish_step("load and open ..."):
-                nano_file = input_file.load(formatter="uproot")
+                # open with uproot
+                with self.publish_step("load and open ..."):
+                    nano_file = input_file[1].load(formatter="uproot")
 
-            # read HLT paths
-            hlt_paths = [
-                key for key in nano_file["Events"].keys()
-                if key.startswith("HLT_")
-            ]
+                # read HLT paths
+                hlt_paths = [
+                    key for key in nano_file["Events"].keys()
+                    if key.startswith("HLT_")
+                ]
 
-            # extend header and rows
-            header.append(fmt(dataset))
-            for trigger, row in zip(self.config_inst.x.triggers, rows):
-                row.append(int(trigger.name in hlt_paths))
+                # extend header and rows
+                postfix = f"\nlfn: {input_file[0]}" if len(lfn_indices) > 1 else ""
+                header.append(fmt(f"{dataset}{postfix}"))
+                for trigger, row in zip(self.config_inst.x.triggers, rows):
+                    row.append(int(trigger.name in hlt_paths))
 
         print("")
         print(tabulate(rows, headers=header, tablefmt=self.table_format))

--- a/hbt/tasks/studies/triggers.py
+++ b/hbt/tasks/studies/triggers.py
@@ -32,7 +32,7 @@ class HBTTriggerTask(HBTTask):
 
     lfn_indices = law.CSVParameter(
         cls=luigi.IntParameter,
-        default=0,
+        default=(0,),
         description="Indices of the LFN to use in the dataset. Defaults to 0.",
         significant=False,
         force_tuple=True,

--- a/law.cfg
+++ b/law.cfg
@@ -38,7 +38,7 @@ job_file_dir_cleanup: False
 
 default_analysis: hbt.config.analysis_hbt.analysis_hbt
 default_config: run3_2022_preEE_limited
-default_dataset: hh_ggf_hbb_htt_kl1_kt1_c20_powheg
+default_dataset: hh_ggf_hbb_htt_kl1_kt1_powheg
 
 production_modules: columnflow.production.{categories,normalization,processes}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds,gen_top_decay}, hbt.production.{default,weights,features,btag,tau,minimal,hh_mass}
 calibration_modules: columnflow.calibration.cms.{jets,met}, hbt.calibration.{default,tau,fake_triggers}


### PR DESCRIPTION
This PR:

- Removes some triggers not needed/used anymore.
- Documents used trigger filters for each trigger
- Corrects the Trigger bits of `HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1`
- Change `HLT_Ele32_WPTight_Gsf` to `HLT_Ele30_WPTight_Gsf`
- Adds the `cross-tau-jet` trigger to the selection