### PR TITLE
stylize run3 processes

### DIFF
--- a/hbt/config/configs_run3.py
+++ b/hbt/config/configs_run3.py
@@ -108,6 +108,19 @@ def add_config(
         # add the process
         cfg.add_process(procs.get(process_name))
 
+    # add a multi-boson process
+    from order import Process
+    multi_boson = Process(
+        name="multi_boson",
+        id=7999,
+        label="Multi-Boson",
+    )
+
+    multi_boson.add_process(cfg.get_process("vv"))
+    multi_boson.add_process(cfg.get_process("vvv"))
+
+    cfg.add_process(multi_boson)
+
     # configure colors, labels, etc
     from hbt.config.styles import stylize_processes
     stylize_processes(cfg)
@@ -227,8 +240,7 @@ def add_config(
             "dy",
             "w",
             "ewk",
-            "vv",
-            "vvv",
+            "multi_boson",
             "qcd",
             "h",
             "hh_ggf_hbb_htt_kl1_kt1",
@@ -255,6 +267,12 @@ def add_config(
     # (used in cutflow tasks)
     cfg.x.selector_step_groups = {
         "default": ["json", "met_filter", "trigger", "lepton", "jet", "bjet"],
+    }
+
+    cfg.x.custom_style_config_groups = {
+        "small_legend": {
+            "legend_cfg": {"ncols": 2, "fontsize": 16, "columnspacing": 0.6},
+        },
     }
 
     # custom method and sandbox for determining dataset lfns

--- a/hbt/config/styles.py
+++ b/hbt/config/styles.py
@@ -12,25 +12,44 @@ def stylize_processes(config: od.Config) -> None:
     Adds process colors and adjust labels.
     """
     if config.has_process("hh_ggf_hbb_htt_kl1_kt1"):
-        config.processes.n.hh_ggf_hbb_htt_kl1_kt1.color1 = (67, 118, 201)
+        config.processes.n.hh_ggf_hbb_htt_kl1_kt1.color1 = "#3f90da"  # old: (67, 118, 201)
+        config.processes.n.hh_ggf_hbb_htt_kl1_kt1.label = r"$HH_{ggf} \rightarrow bb\tau\tau$" + " \n " + r"($\kappa_{\lambda}=1$, $\kappa_{t}=1$)"  # noqa
 
     if config.has_process("hh_vbf_hbb_htt_kv1_k2v1_kl1"):
-        config.processes.n.hh_vbf_hbb_htt_kv1_k2v1_kl1.color1 = (86, 211, 71)
+        config.processes.n.hh_vbf_hbb_htt_kv1_k2v1_kl1.color1 = "#011c87"  # old: (86, 211, 71)
 
     if config.has_process("h"):
-        config.processes.n.h.color1 = (65, 180, 219)
+        config.processes.n.h.color1 = "#92dadd"  # old: (65, 180, 219)
 
     if config.has_process("tt"):
-        config.processes.n.tt.color1 = (244, 182, 66)
+        config.processes.n.tt.color1 = "#ffa90e"  # old: (244, 182, 66)
 
     if config.has_process("st"):
-        config.processes.n.st.color1 = (244, 93, 66)
+        config.processes.n.st.color1 = "#e76300"  # old: (244, 93, 66)
 
     if config.has_process("dy"):
-        config.processes.n.dy.color1 = (68, 186, 104)
+        config.processes.n.dy.color1 = "#bd1f01"  # old: (68, 186, 104)
 
     if config.has_process("vv"):
-        config.processes.n.vv.color1 = (2, 24, 140)
+        config.processes.n.vv.color1 = "#832db6"  # old: (2, 24, 140)
+
+    if config.has_process("w"):
+        config.processes.n.w.color1 = "#717581"
+
+    if config.has_process("ewk"):
+        config.processes.n.ewk.color1 = "#b9ac70"
+
+    # if config.has_process("ttv"):
+    #     config.processes.n.ttv.color1 = "#f7c331"
+
+    if config.has_process("ttvv"):
+        config.processes.n.ttvv.color1 = "#a96b59"
+
+    if config.has_process("vvv"):
+        config.processes.n.vvv.color1 = "#832db6"
+
+    if config.has_process("multi_boson"):
+        config.processes.n.multi_boson.color1 = "#832db6"
 
     if config.has_process("qcd"):
-        config.processes.n.qcd.color1 = (242, 149, 99)
+        config.processes.n.qcd.color1 = "#94a4a2"  # old: (242, 149, 99)


### PR DESCRIPTION
update columnflow, add new style config with smaller legend, number of columns, and reduced space between columns (triggered with --custom-style-config small_legend), change color processes and label for HH->bbtautau, add custom multi_boson process