### PR TITLE
Add task to find overlapping events between custom and central NANOAOD

### DIFF
--- a/hbt/config/configs_hbt.py
+++ b/hbt/config/configs_hbt.py
@@ -48,7 +48,14 @@ def add_config(
     procs = get_root_processes_from_campaign(campaign)
 
     # create a config by passing the campaign, so id and name will be identical
-    cfg = od.Config(name=config_name, id=config_id, campaign=campaign)
+    cfg = od.Config(
+        name=config_name,
+        id=config_id,
+        campaign=campaign,
+        aux={
+            "sync": sync_mode,
+        },
+    )
 
     ################################################################################################
     # helpers

--- a/hbt/tasks/sync.py
+++ b/hbt/tasks/sync.py
@@ -98,9 +98,6 @@ class CheckExternalLFNOverlap(
                 file_arr = ak.values_astype(file_arr, np.int64)
                 # apply mask, convert record to regulare array via view
                 overlap_identifiers[str(i)] = file_arr[overlapping_mask]
-                # convert each entry to tuple to be saved in json
-
-
 
         output["overlap"].dump(
             overlap_relative,
@@ -131,8 +128,8 @@ class CreateSyncFiles(
     RemoteWorkflow,
 ):
     overlap_file = luigi.Parameter(
-    description="local path to an optional json file created by CheckExternalLFNOverlap task",
-    default=None,
+        description="local path to an optional json file created by CheckExternalLFNOverlap task",
+        default=None,
     )
 
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
@@ -271,11 +268,11 @@ class CreateSyncFiles(
 
                 # calculate the mask
                 overlapping_mask = np.isin(
-                chunk_hashes,
-                overlap_hashes,
-                assume_unique=True,
-                kind="sort",
-            )
+                    chunk_hashes,
+                    overlap_hashes,
+                    assume_unique=True,
+                    kind="sort",
+                )
 
             # apply mask
             events = events[overlapping_mask]

--- a/hbt/tasks/sync.py
+++ b/hbt/tasks/sync.py
@@ -210,7 +210,10 @@ class CreateSyncFiles(
 
         # helper to pad and select the last element on the first inner axis
         def select(arr, idx):
-            return replace_empty_float(pad_nested(arr, idx + 1, axis=1)[:, idx])
+            if arr.ndim == 1:
+                return replace_empty_float(pad_nested(arr, idx + 1, axis=-1))
+            else:
+                return replace_empty_float(pad_nested(arr, idx + 1, axis=1)[:, idx])
 
         # helper to select leptons
         def select_leptons(events: ak.Array, common_fields: dict[str, int | float]) -> ak.Array:

--- a/hbt/tasks/sync.py
+++ b/hbt/tasks/sync.py
@@ -36,7 +36,7 @@ class CheckExternalLFNOverlap(
         default="/pnfs/desy.de/cms/tier2/store/user/mrieger/nanogen_store/FetchLFN/store/mc/Run3Summer22NanoAODv12/GluGlutoHHto2B2Tau_kl-1p00_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_v5-v2/50000/992697da-4a10-4435-b63a-413f6d33517e.root",  # noqa
     )
 
-    # no versioning or required
+    # no versioning required
     version = None
 
     # default sandbox, might be overwritten by calibrator function
@@ -210,10 +210,8 @@ class CreateSyncFiles(
 
         # helper to pad and select the last element on the first inner axis
         def select(arr, idx):
-            if arr.ndim == 1:
-                return replace_empty_float(pad_nested(arr, idx + 1, axis=-1))
-            else:
-                return replace_empty_float(pad_nested(arr, idx + 1, axis=1)[:, idx])
+            padded = pad_nested(arr, idx + 1, axis=-1)
+            return replace_empty_float(padded if arr.ndim == 1 else padded[:, idx])
 
         # helper to select leptons
         def select_leptons(events: ak.Array, common_fields: dict[str, int | float]) -> ak.Array:
@@ -292,7 +290,6 @@ class CreateSyncFiles(
                 "lep2_eta": select(events.Lepton.eta, 1),
                 "lep2_charge": select(events.Lepton.charge, 1),
                 "lep2_deeptauvsjet": select(events.Lepton.rawDeepTau2018v2p5VSjet, 1),
-                # TODO: add additional variables
                 "electron1_charge": select(events.Electron.charge, 0),
                 "electron1_eta": select(events.Electron.eta, 0),
                 "electron1_mass": select(events.Electron.mass, 0),
@@ -350,11 +347,6 @@ class CreateSyncFiles(
                 "fatjet2_tau2": select(events.FatJet.tau2, 1),
                 "fatjet2_tau3": select(events.FatJet.tau3, 1),
                 "fatjet2_tau4": select(events.FatJet.tau4, 1),
-
-
-
-
-
             })
 
             # save as csv in output, append if necessary

--- a/hbt/tasks/sync.py
+++ b/hbt/tasks/sync.py
@@ -293,6 +293,68 @@ class CreateSyncFiles(
                 "lep2_charge": select(events.Lepton.charge, 1),
                 "lep2_deeptauvsjet": select(events.Lepton.rawDeepTau2018v2p5VSjet, 1),
                 # TODO: add additional variables
+                "electron1_charge": select(events.Electron.charge, 0),
+                "electron1_eta": select(events.Electron.eta, 0),
+                "electron1_mass": select(events.Electron.mass, 0),
+                "electron1_phi": select(events.Electron.phi, 0),
+                "electron1_pt": select(events.Electron.pt, 0),
+                "electron2_charge": select(events.Electron.charge, 1),
+                "electron2_eta": select(events.Electron.eta, 1),
+                "electron2_mass": select(events.Electron.mass, 1),
+                "electron2_phi": select(events.Electron.phi, 1),
+                "electron2_pt": select(events.Electron.pt, 1),
+
+                "muon1_charge": select(events.Muon.charge, 0),
+                "muon1_eta": select(events.Muon.eta, 0),
+                "muon1_mass": select(events.Muon.mass, 0),
+                "muon1_phi": select(events.Muon.phi, 0),
+                "muon1_pt": select(events.Muon.pt, 0),
+                "muon2_charge": select(events.Muon.charge, 1),
+                "muon2_eta": select(events.Muon.eta, 1),
+                "muon2_mass": select(events.Muon.mass, 1),
+                "muon2_phi": select(events.Muon.phi, 1),
+                "muon2_pt": select(events.Muon.pt, 1),
+
+                "tau1_charge": select(events.Tau.charge, 0),
+                "tau1_eta": select(events.Tau.eta, 0),
+                "tau1_mass": select(events.Tau.mass, 0),
+                "tau1_phi": select(events.Tau.phi, 0),
+                "tau1_pt": select(events.Tau.pt, 0),
+                "tau2_charge": select(events.Tau.charge, 1),
+                "tau2_eta": select(events.Tau.eta, 1),
+                "tau2_mass": select(events.Tau.mass, 1),
+                "tau2_phi": select(events.Tau.phi, 1),
+                "tau2_pt": select(events.Tau.pt, 1),
+
+                "met1_covXX": select(events.MET.covXX, 0),
+                "met1_covXY": select(events.MET.covXY, 0),
+                "met1_covYY": select(events.MET.covYY, 0),
+                "met1_phi": select(events.MET.phi, 0),
+                "met1_pt": select(events.MET.pt, 0),
+                "met1_significance": select(events.MET.significance, 0),
+
+                "fatjet1_eta": select(events.FatJet.eta, 0),
+                "fatjet1_mass": select(events.FatJet.mass, 0),
+                "fatjet1_phi": select(events.FatJet.phi, 0),
+                "fatjet1_pt": select(events.FatJet.pt, 0),
+                "fatjet1_tau1": select(events.FatJet.tau1, 0),
+                "fatjet1_tau2": select(events.FatJet.tau2, 0),
+                "fatjet1_tau3": select(events.FatJet.tau3, 0),
+                "fatjet1_tau4": select(events.FatJet.tau4, 0),
+
+                "fatjet2_eta": select(events.FatJet.eta, 1),
+                "fatjet2_mass": select(events.FatJet.mass, 1),
+                "fatjet2_phi": select(events.FatJet.phi, 1),
+                "fatjet2_pt": select(events.FatJet.pt, 1),
+                "fatjet2_tau1": select(events.FatJet.tau1, 1),
+                "fatjet2_tau2": select(events.FatJet.tau2, 1),
+                "fatjet2_tau3": select(events.FatJet.tau3, 1),
+                "fatjet2_tau4": select(events.FatJet.tau4, 1),
+
+
+
+
+
             })
 
             # save as csv in output, append if necessary

--- a/hbt/tasks/sync.py
+++ b/hbt/tasks/sync.py
@@ -109,7 +109,7 @@ class CheckExternalLFNOverlap(
 
     @classmethod
     def load_nano_index(cls, lfn_target: law.FileSystemFileTarget) -> set[int]:
-        fields = ["event", "run", "luminosityBlock"]
+        fields = ["event", "luminosityBlock", "run"]
         arr = lfn_target.load(formatter="uproot")["Events"].arrays(fields)
         return arr
 

--- a/hbt/tasks/sync.py
+++ b/hbt/tasks/sync.py
@@ -76,7 +76,6 @@ class CheckExternalLFNOverlap(
             with self.publish_step(f"loading ids of file {i}"):
                 file_arr = self.load_nano_index(lfn_target)
                 file_hashes = hash_events(file_arr)
-
             # find unique hashes in the reference and the file
             # faster than np.
             overlapping_mask = np.isin(
@@ -123,7 +122,7 @@ class CreateSyncFiles(
 ):
     filter_file = luigi.Parameter(
         description="local path to a file containing event unique identifier to filter them out",
-        default=None,
+        default="",
     )
 
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -10,6 +10,9 @@ __all__ = []
 
 from columnflow.types import Any
 from columnflow.columnar_util import ArrayFunction, deferred_column
+from columnflow.util import maybe_import
+
+np = maybe_import("numpy")
 
 
 @deferred_column
@@ -65,7 +68,6 @@ def hash_events(arr: np.ndarray) -> np.ndarray:
     The values are padded to specific lengths and concatenated to a single integer.
     """
     import awkward as ak
-    import numpy as np
 
     def assert_value(arr: np.ndarray, field: str, max_value: int) -> None:
         """

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -58,6 +58,7 @@ def IF_DATASET_IS_DY(
 
     return self.get() if func.dataset_inst.has_tag("is_dy") else None
 
+
 def hash_events(arr):
     """
     Helper function to create a hash value from the event, run and luminosityBlock columns.

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -57,3 +57,19 @@ def IF_DATASET_IS_DY(
         return self.get()
 
     return self.get() if func.dataset_inst.has_tag("is_dy") else None
+
+def hash_events(arr):
+    """
+    Helper function to create a hash value from the event, run and luminosityBlock columns.
+    The result is a number with 15 digits, where the first 7 digits are the luminosityBlock,
+    the next 5 digits are the event number and the last 3 digits are the run number.
+    """
+    # hash the array by pad the numbers to specific lengths by shifting them
+    # shift luminosityBlock: 10^3, event: 10^7
+    # example:
+    hash_value = (
+        arr.event * 10**7 +
+        arr.luminosityBlock * 10**3 +
+        arr.run
+    )
+    return hash_value

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -78,15 +78,17 @@ def hash_events(arr: np.ndarray) -> np.ndarray:
 
     max_digits_run = 6
     max_digits_luminosityBlock = 5
-    max_digits_event = 7
-
+    max_digits_event = 8
     assert_value(arr, "run", max_digits_run)
     assert_value(arr, "luminosityBlock", max_digits_luminosityBlock)
     assert_value(arr, "event", max_digits_event)
+
+    max_digits_hash = max_digits_event + max_digits_luminosityBlock + max_digits_run
+    assert max_digits_hash <= 19, "sum of digits exceeds int64"
+
     # upcast to int64 to avoid overflow
-    arr = ak.values_astype(arr, np.int64)
     return (
-        arr.event * 10**(max_digits_luminosityBlock + max_digits_run) +
-        arr.luminosityBlock * 10**max_digits_run +
-        arr.run
+        ak.values_astype(arr.event, np.int64) * 10**(max_digits_luminosityBlock + max_digits_run) +
+        ak.values_astype(arr.luminosityBlock, np.int64) * 10**max_digits_run +
+        ak.values_astype(arr.run, np.int64)
     )

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -62,15 +62,15 @@ def IF_DATASET_IS_DY(
 def hash_events(arr):
     """
     Helper function to create a hash value from the event, run and luminosityBlock columns.
-    The result is a number with 15 digits, where the first 7 digits are the luminosityBlock,
-    the next 5 digits are the event number and the last 3 digits are the run number.
+    The values are padded to specific lengths and concatenated to a single integer.
     """
-    # hash the array by pad the numbers to specific lengths by shifting them
-    # shift luminosityBlock: 10^3, event: 10^7
-    # example:
+    # TODO what is a good value here?
+    max_digits_run = 4
+    max_digits_luminosityBlock = 3 + max_digits_run
+
     hash_value = (
-        arr.event * 10**7 +
-        arr.luminosityBlock * 10**3 +
+        arr.event * 10**max_digits_luminosityBlock +
+        arr.luminosityBlock * 10**max_digits_run +
         arr.run
     )
     return hash_value

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -11,8 +11,6 @@ __all__ = []
 from columnflow.types import Any
 from columnflow.columnar_util import ArrayFunction, deferred_column
 
-import numpy as np
-
 
 @deferred_column
 def IF_NANO_V9(self: ArrayFunction.DeferredColumn, func: ArrayFunction) -> Any | set[Any]:
@@ -66,13 +64,16 @@ def hash_events(arr: np.ndarray) -> np.ndarray:
     Helper function to create a hash value from the event, run and luminosityBlock columns.
     The values are padded to specific lengths and concatenated to a single integer.
     """
+    import awkward as ak
+    import numpy as np
+
     def assert_value(arr: np.ndarray, field: str, max_value: int) -> None:
         """
         Helper function to check if a column does not exceed a maximum value.
         """
         digits = len(str(arr[field].to_numpy().max()))
         assert digits <= max_value, f"{field} digit count is {digits} and exceed max value {max_value}"
-    import awkward as ak
+
     max_digits_run = 6
     max_digits_luminosityBlock = 5
     max_digits_event = 7

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -72,7 +72,7 @@ def hash_events(arr: np.ndarray) -> np.ndarray:
         """
         digits = len(str(arr[field].to_numpy().max()))
         assert digits <= max_value, f"{field} digit count is {digits} and exceed max value {max_value}"
-
+    import awkward as ak
     max_digits_run = 6
     max_digits_luminosityBlock = 5
     max_digits_event = 7
@@ -80,10 +80,10 @@ def hash_events(arr: np.ndarray) -> np.ndarray:
     assert_value(arr, "run", max_digits_run)
     assert_value(arr, "luminosityBlock", max_digits_luminosityBlock)
     assert_value(arr, "event", max_digits_event)
-
-    hash_value = (
+    # upcast to int64 to avoid overflow
+    arr = ak.values_astype(arr, np.int64)
+    return (
         arr.event * 10**(max_digits_luminosityBlock + max_digits_run) +
         arr.luminosityBlock * 10**max_digits_run +
         arr.run
     )
-    return hash_value


### PR DESCRIPTION
Due to different compressions, our custom and the central NANOAODs events order is not the same. 
During our  syncronisation efforts we need to find out if differences between the frameworks comes from different NANOs or due to differences within the frameworks.  

This PR adds a task to tackle this issue. It will look up the overlapping events and finds the relative overlap per chunk, as well as a list of unique identifier tuples to create a filtering mask.