### PR TITLE
Add patch_ecalBadCalibFilter.

### DIFF
--- a/hbt/config/configs_hbt.py
+++ b/hbt/config/configs_hbt.py
@@ -355,6 +355,10 @@ def add_config(
                 dataset.add_tag("ggf")
             elif dataset_name.startswith(("graviton_hh_vbf_", "radion_hh_vbf")):
                 dataset.add_tag("vbf")
+        # bad ecalBadCalibFilter MET filter in 2022 data
+        # see https://cms-talk.web.cern.ch/t/noise-met-filters-in-run-3/63346/5
+        if year == 2022 and dataset.is_data and dataset.x.era in "FG":
+            dataset.add_tag("broken_ecalBadCalibFilter")
 
         # apply an optional limit on the number of files
         if limit_dataset_files:

--- a/hbt/production/patches.py
+++ b/hbt/production/patches.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+
+"""
+Producers creating columns that make up for broken values in NanoAOD or other upstream methods.
+"""
+
+from __future__ import annotations
+
+from columnflow.production import Producer, producer
+from columnflow.columnar_util import set_ak_column
+from columnflow.util import maybe_import
+
+ak = maybe_import("awkward")
+
+
+@producer(
+    uses={"PuppiMET.{pt,phi}", "Jet.{pt,eta,phi,neEmEF,chEmEF}"},
+    produces={"patchedEcalBadCalibFilter"},
+)
+def patch_ecalBadCalibFilter(
+    self: Producer,
+    events: ak.Array,
+    **kwargs,
+) -> ak.Array:
+    """
+    Patch for the broken "Flag_ecalBadCalibFilter" MET filter in prompt (not re-reco-ed) 2022 data.
+    As for all MET filters, the output is a boolean that is true if the event passes the filter.
+
+    Resources:
+    - Discussion: https://cms-talk.web.cern.ch/t/noise-met-filters-in-run-3/63346/5
+    - TWiki: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2?rev=172
+    """
+    reject = (
+        (events.PuppiMET.pt > 100) &
+        ak.any(
+            (events.Jet.pt > 50) &
+            (events.Jet.eta >= -0.5) &
+            (events.Jet.eta <= -0.1) &
+            (events.Jet.phi >= -2.1) &
+            (events.Jet.phi <= -1.8) &
+            ((events.Jet.neEmEF > 0.9) | (events.Jet.chEmEF > 0.9)) &
+            (events.Jet.delta_phi(events.PuppiMET) > 2.9),
+            axis=1,
+        )
+    )
+    return set_ak_column(events, "patchedEcalBadCalibFilter", ~reject)

--- a/hbt/production/patches.py
+++ b/hbt/production/patches.py
@@ -28,8 +28,8 @@ def patch_ecalBadCalibFilter(
 
     Resources:
     - Discussion: https://cms-talk.web.cern.ch/t/noise-met-filters-in-run-3/63346/5
-    - TWiki: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2?rev=172
-    """
+    - TWiki: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2?rev=172#ECal_BadCalibration_Filter_Flag
+    """  # noqa
     reject = (
         (events.PuppiMET.pt > 100) &
         ak.any(

--- a/law.cfg
+++ b/law.cfg
@@ -43,7 +43,7 @@ default_dataset: hh_ggf_hbb_htt_kl1_kt1_powheg
 
 calibration_modules: columnflow.calibration.cms.{jets,met,tau}, hbt.calibration.{default,fake_triggers}
 selection_modules: columnflow.selection.empty, columnflow.selection.cms.{json_filter,met_filters}, hbt.selection.{default,lepton,trigger}
-production_modules: columnflow.production.{categories,normalization,processes}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds,gen_top_decay}, hbt.production.{default,weights,features,btag,tau,minimal,hh_mass,res_networks}
+production_modules: columnflow.production.{categories,normalization,processes}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds,gen_top_decay}, hbt.production.{default,weights,features,btag,tau,minimal,hh_mass,res_networks,patches}
 categorization_modules: hbt.categorization.default
 weight_production_modules: columnflow.weight.{empty,all_weights}, hbt.weight.default
 ml_modules: hbt.ml.test


### PR DESCRIPTION
This PR adds a producer for patching the broken `Flag_ecalBadCalibFilter` met filter decision in prompt 2022 data (postEE, eras F + G).

The patch is configured / used in 2 steps:

1. In our main config, datasets which are known to have broken flags are tagged as `broken_ecalBadCalibFilter`. This is done here in order to move all decisions about special treatments into the config, rather than having them scattered across many files.
2. The producer is called as part of the default selector, right after the nominal `met_filter` step. In case a dataset with the above mentioned tag is encountered, the producer is invoked and its result is `&`-ed to the met filter result step.


---

Resources:

- Discussion: https://cms-talk.web.cern.ch/t/noise-met-filters-in-run-3/63346/5
- TWiki: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2?rev=172#ECal_BadCalibration_Filter_Flag
