### PR TITLE
Generalize process id producer and stitching configuration and include stitching for w_lnu samples

### DIFF
--- a/hbt/config/configs_hbt.py
+++ b/hbt/config/configs_hbt.py
@@ -415,28 +415,61 @@ def add_config(
 
     # define inclusive datasets for the stitched process identification with corresponding leaf processes
     if run == 3 and not sync_mode:
-        # drell-yan
-        cfg.x.dy_stitching = {
-            "m50toinf": {
-                "inclusive_dataset": cfg.datasets.n.dy_m50toinf_amcatnlo,
-                "leaf_processes": [
-                    # the following processes cover the full njet and pt phasespace
-                    procs.n.dy_m50toinf_0j,
-                    *(
-                        procs.get(f"dy_m50toinf_{nj}j_pt{pt}")
-                        for nj in [1, 2]
-                        for pt in ["0to40", "40to100", "100to200", "200to400", "400to600", "600toinf"]
-                    ),
-                    procs.n.dy_m50toinf_ge3j,
-                ],
+        # stitchting definitions
+        # format:
+        # {
+        #   "dataset_tag": {
+        #       "dataset_to_stitch": {
+        #           "inclusive_dataset": dataset,
+        #           "leaf_processes": [proc1, proc2, ...],
+        #       },
+        #   }
+        # }
+        cfg.x.stitching = {
+            # DY stitching
+            "is_dy": {
+                "m50toinf": {
+                    "inclusive_dataset": cfg.datasets.n.dy_m50toinf_amcatnlo,
+                    "leaf_processes": [
+                        # the following processes cover the full njet and pt phasespace
+                        procs.n.dy_m50toinf_0j,
+                        *(
+                            procs.get(f"dy_m50toinf_{nj}j_pt{pt}")
+                            for nj in [1, 2]
+                            for pt in ["0to40", "40to100", "100to200", "200to400", "400to600", "600toinf"]
+                        ),
+                        procs.n.dy_m50toinf_ge3j,
+                    ],
+                },
             },
+            # w+jets
+            # TODO: add
         }
-        # w+jets
-        # TODO: add
+        
 
     # dataset groups for conveniently looping over certain datasets
     # (used in wrapper_factory and during plotting)
-    cfg.x.dataset_groups = {}
+    cfg.x.dataset_groups = {
+        "dy": [
+            # dy
+            "dy_m4to10_amcatnlo",
+            "dy_m10to50_amcatnlo",
+            "dy_m50toinf_amcatnlo",
+            "dy_m50toinf_0j_amcatnlo",
+            "dy_m50toinf_1j_amcatnlo",
+            "dy_m50toinf_2j_amcatnlo",
+            "dy_m50toinf_1j_pt40to100_amcatnlo",
+            "dy_m50toinf_1j_pt100to200_amcatnlo",
+            "dy_m50toinf_1j_pt200to400_amcatnlo",
+            "dy_m50toinf_1j_pt400to600_amcatnlo",
+            "dy_m50toinf_1j_pt600toinf_amcatnlo",
+            "dy_m50toinf_2j_pt40to100_amcatnlo",
+            "dy_m50toinf_2j_pt100to200_amcatnlo",
+            "dy_m50toinf_2j_pt200to400_amcatnlo",
+            "dy_m50toinf_2j_pt400to600_amcatnlo",
+            "dy_m50toinf_2j_pt600toinf_amcatnlo",
+        ],
+    }
 
     # category groups for conveniently looping over certain categories
     # (used during plotting)

--- a/hbt/config/configs_hbt.py
+++ b/hbt/config/configs_hbt.py
@@ -111,6 +111,7 @@ def add_config(
         "tt",
         "st",
         "dy",
+        "w_lnu",
         "v",
         "multiboson",
         "tt_multiboson",
@@ -344,7 +345,9 @@ def add_config(
         if dataset.name.startswith("st_"):
             dataset.add_tag({"has_top", "single_top", "st"})
         if dataset.name.startswith("dy_"):
-            dataset.add_tag("dy")
+            dataset.add_tag("is_dy")
+        if dataset.name.startswith("w_lnu_"):
+            dataset.add_tag("is_w_lnu")
         if re.match(r"^(ww|wz|zz)_.*pythia$", dataset.name):
             dataset.add_tag("no_lhe_weights")
         if dataset_name.startswith("hh_"):
@@ -435,25 +438,46 @@ def add_config(
         #       },
         #   }
         # }
+        from hbt.production.processes import process_ids_dy, process_ids_wjets
         cfg.x.stitching = {
             # DY stitching
             "is_dy": {
-                "m50toinf": {
-                    "inclusive_dataset": cfg.datasets.n.dy_m50toinf_amcatnlo,
-                    "leaf_processes": [
-                        # the following processes cover the full njet and pt phasespace
-                        procs.n.dy_m50toinf_0j,
-                        *(
-                            procs.get(f"dy_m50toinf_{nj}j_pt{pt}")
-                            for nj in [1, 2]
-                            for pt in ["0to40", "40to100", "100to200", "200to400", "400to600", "600toinf"]
-                        ),
-                        procs.n.dy_m50toinf_ge3j,
-                    ],
-                },
+                "base_producer": process_ids_dy,
+                "info": {
+                    "m50toinf": {
+                        "inclusive_dataset": cfg.datasets.n.dy_m50toinf_amcatnlo,
+                        "leaf_processes": [
+                            # the following processes cover the full njet and pt phasespace
+                            procs.n.dy_m50toinf_0j,
+                            *(
+                                procs.get(f"dy_m50toinf_{nj}j_pt{pt}")
+                                for nj in [1, 2]
+                                for pt in ["0to40", "40to100", "100to200", "200to400", "400to600", "600toinf"]
+                            ),
+                            procs.n.dy_m50toinf_ge3j,
+                        ],
+                    },
+                }
             },
             # w+jets
             # TODO: add
+            "is_w_lnu": {
+                "base_producer": process_ids_wjets,
+                "info": {
+                    "m50toinf": {
+                        "inclusive_dataset": cfg.datasets.n.w_lnu_amcatnlo,
+                        "leaf_processes": [
+                            # the following processes cover the full njet and pt phasespace
+                            procs.n.w_lnu_0j,
+                            *(
+                                procs.get(f"w_lnu_{nj}j_pt{pt}")
+                                for nj in [1, 2]
+                                for pt in ["0to40", "40to100", "100to200", "200to400", "400to600", "600toinf"]
+                            ),
+                        ],
+                    },
+                }
+            },
         }
         
 
@@ -478,6 +502,24 @@ def add_config(
             "dy_m50toinf_2j_pt200to400_amcatnlo",
             "dy_m50toinf_2j_pt400to600_amcatnlo",
             "dy_m50toinf_2j_pt600toinf_amcatnlo",
+        ],
+        "w_lnu": [
+            # w_lnu
+            "w_lnu_amcatnlo",
+            "w_lnu_amcatnlo",
+            "w_lnu_0j_amcatnlo",
+            "w_lnu_1j_amcatnlo",
+            "w_lnu_2j_amcatnlo",
+            "w_lnu_1j_pt40to100_amcatnlo",
+            "w_lnu_1j_pt100to200_amcatnlo",
+            "w_lnu_1j_pt200to400_amcatnlo",
+            "w_lnu_1j_pt400to600_amcatnlo",
+            "w_lnu_1j_pt600toinf_amcatnlo",
+            "w_lnu_2j_pt40to100_amcatnlo",
+            "w_lnu_2j_pt100to200_amcatnlo",
+            "w_lnu_2j_pt200to400_amcatnlo",
+            "w_lnu_2j_pt400to600_amcatnlo",
+            "w_lnu_2j_pt600toinf_amcatnlo",
         ],
     }
 

--- a/hbt/production/processes.py
+++ b/hbt/production/processes.py
@@ -3,16 +3,18 @@
 """
 Process ID producer relevant for the stitching of the DY samples.
 """
-
+from __future__ import annotations
 import functools
 
 import law
+import order
 
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import, InsertableDict
-from columnflow.columnar_util import set_ak_column
+from columnflow.columnar_util import set_ak_column, Route
 
 from hbt.util import IF_DATASET_IS_DY
+from columnflow.types import Callable
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -27,61 +29,135 @@ PtRange = tuple[float, float]
 
 set_ak_column_i64 = functools.partial(set_ak_column, value_type=np.int64)
 
+class stitched_process_ids(Producer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.key_func: Callable or None = None
+        self.cross_check_func: Callable or None = self.cross_check_func
+        self.stichting_observabes: list[str] or None = None
+        self.cross_check_translation_dict: dict[str, str] or None = None
 
-@producer(
-    uses={IF_DATASET_IS_DY("LHE.NpNLO", "LHE.Vpt")},
-    produces={IF_DATASET_IS_DY("process_id")},
+    def init_func(self, *args, **kwargs):
+        self.uses |= {IF_DATASET_IS_DY(*self.stichting_observabes)}
+        self.produces |= {IF_DATASET_IS_DY("process_id")}
+
+    def call_func(self, events: ak.Array, **kwargs) -> ak.Array:
+        """
+        Assigns each event a single process id, based on the stitching observables of
+        the LHE record. This is used for the stitching of the respective samples.
+        """
+        # as always, we assume that each dataset has exactly one process associated to it
+        if len(self.dataset_inst.processes) != 1:
+            raise NotImplementedError(
+                f"dataset {self.dataset_inst.name} has {len(self.dataset_inst.processes)} processes "
+                "assigned, which is not yet implemented",
+            )
+        process_inst = self.dataset_inst.processes.get_first()
+
+        # # get the number of nlo jets and the di-lepton pt
+        # njets = events.LHE.NpNLO
+        # pt = events.LHE.Vpt
+        # get stitching observables
+        stitching_obs_values = [Route(obs).apply(events) for obs in self.stichting_observabes]
+
+        if self.cross_check_translation_dict and callable(self.cross_check_func):
+            self.cross_check_func(process_inst, stitching_obs_values)
+
+        # lookup the id and check for invalid values
+        process_ids = np.squeeze(np.asarray(self.id_table[self.key_func(*stitching_obs_values)].todense()))
+        invalid_mask = process_ids == 0
+        if ak.any(invalid_mask):
+            raise ValueError(
+                f"found {sum(invalid_mask)} events that could not be assigned to a process",
+            )
+
+        # store them
+        events = set_ak_column_i64(events, "process_id", process_ids)
+
+        return events
+
+
+    def stitching_range_cross_check(
+        self: Producer,
+        process_inst: order.Process,
+        stichting_values: list[ak.Array]
+    ) -> None:
+        # define lookup for stichting observable -> process auxiliary values to compare with
+        # raise a warning if a datasets was already created for a specific "bin" (leaf process),
+        # but actually does not fit
+        for obs_name, obs_values in zip(self.stichting_observabes, stichting_values):
+            aux_name = self.cross_check_translation_dict.get(obs_name, obs_name)
+            aux_values = process_inst.x(aux_name, None)
+            if aux_values is not None:
+                outliers = (obs_values < aux_values[0]) | (obs_values >= aux_values[1])
+                if ak.any(outliers):
+                    logger.warning(
+                        f"dataset {self.dataset_inst.name} is meant to contain {aux_name} "
+                        f"values in the range [{aux_values[0]}, {aux_values[0]}), but found {ak.sum(outliers)} "
+                        "events outside this range",
+                    )
+
+process_ids_dy = stitched_process_ids.derive(
+    "process_ids_dy", cls_dict={
+        "stichting_observabes": ["LHE.NpNLO", "LHE.Vpt"],
+        "cross_check_translation_dict": {"LHE.NpNLO": "njets", "LHE.Vpt": "ptll"},
+    },
 )
-def process_ids_dy(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
-    """
-    Assigns each dy event a single process id, based on the number of jets and the di-lepton pt of
-    the LHE record. This is used for the stitching of the DY samples.
-    """
-    # as always, we assume that each dataset has exactly one process associated to it
-    if len(self.dataset_inst.processes) != 1:
-        raise NotImplementedError(
-            f"dataset {self.dataset_inst.name} has {len(self.dataset_inst.processes)} processes "
-            "assigned, which is not yet implemented",
-        )
-    process_inst = self.dataset_inst.processes.get_first()
 
-    # get the number of nlo jets and the di-lepton pt
-    njets = events.LHE.NpNLO
-    pt = events.LHE.Vpt
+# @producer(
+#     uses={IF_DATASET_IS_DY("LHE.NpNLO", "LHE.Vpt")},
+#     produces={IF_DATASET_IS_DY("process_id")},
+# )
+# def process_ids_dy(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+#     """
+#     Assigns each dy event a single process id, based on the number of jets and the di-lepton pt of
+#     the LHE record. This is used for the stitching of the DY samples.
+#     """
+#     # as always, we assume that each dataset has exactly one process associated to it
+#     if len(self.dataset_inst.processes) != 1:
+#         raise NotImplementedError(
+#             f"dataset {self.dataset_inst.name} has {len(self.dataset_inst.processes)} processes "
+#             "assigned, which is not yet implemented",
+#         )
+#     process_inst = self.dataset_inst.processes.get_first()
 
-    # raise a warning if a datasets was already created for a specific "bin" (leaf process),
-    # but actually does not fit
-    njets_range = process_inst.x("njets", None)
-    if njets_range is not None:
-        outliers = (njets < njets_range[0]) | (njets >= njets_range[1])
-        if ak.any(outliers):
-            logger.warning(
-                f"dataset {self.dataset_inst.name} is meant to contain njet values in the range "
-                f"[{njets_range[0]}, {njets_range[0]}), but found {ak.sum(outliers)} events "
-                "outside this range",
-            )
-    pt_range = process_inst.x("ptll", None)
-    if pt_range is not None:
-        outliers = (pt < pt_range[0]) | (pt >= pt_range[1])
-        if ak.any(outliers):
-            logger.warning(
-                f"dataset {self.dataset_inst.name} is meant to contain ptll values in the range "
-                f"[{pt_range[0]}, {pt_range[1]}), but found {ak.sum(outliers)} events outside this "
-                "range",
-            )
+#     # get the number of nlo jets and the di-lepton pt
+#     njets = events.LHE.NpNLO
+#     pt = events.LHE.Vpt
 
-    # lookup the id and check for invalid values
-    process_ids = np.squeeze(np.asarray(self.id_table[self.key_func(njets, pt)].todense()))
-    invalid_mask = process_ids == 0
-    if ak.any(invalid_mask):
-        raise ValueError(
-            f"found {sum(invalid_mask)} dy events that could not be assigned to a process",
-        )
+#     # raise a warning if a datasets was already created for a specific "bin" (leaf process),
+#     # but actually does not fit
+#     njets_range = process_inst.x("njets", None)
+#     if njets_range is not None:
+#         outliers = (njets < njets_range[0]) | (njets >= njets_range[1])
+#         if ak.any(outliers):
+#             logger.warning(
+#                 f"dataset {self.dataset_inst.name} is meant to contain njet values in the range "
+#                 f"[{njets_range[0]}, {njets_range[0]}), but found {ak.sum(outliers)} events "
+#                 "outside this range",
+#             )
+#     pt_range = process_inst.x("ptll", None)
+#     if pt_range is not None:
+#         outliers = (pt < pt_range[0]) | (pt >= pt_range[1])
+#         if ak.any(outliers):
+#             logger.warning(
+#                 f"dataset {self.dataset_inst.name} is meant to contain ptll values in the range "
+#                 f"[{pt_range[0]}, {pt_range[1]}), but found {ak.sum(outliers)} events outside this "
+#                 "range",
+#             )
 
-    # store them
-    events = set_ak_column_i64(events, "process_id", process_ids)
+#     # lookup the id and check for invalid values
+#     process_ids = np.squeeze(np.asarray(self.id_table[self.key_func(njets, pt)].todense()))
+#     invalid_mask = process_ids == 0
+#     if ak.any(invalid_mask):
+#         raise ValueError(
+#             f"found {sum(invalid_mask)} dy events that could not be assigned to a process",
+#         )
 
-    return events
+#     # store them
+#     events = set_ak_column_i64(events, "process_id", process_ids)
+
+#     return events
 
 
 @process_ids_dy.setup

--- a/hbt/selection/default.py
+++ b/hbt/selection/default.py
@@ -192,8 +192,9 @@ def default_init(self: Selector) -> None:
 
     self.process_ids_dy: process_ids_dy | None = None
     if self.dataset_inst.has_tag("is_dy"):
+        dy_stitching = self.config_inst.x.stitching["is_dy"]
         # check if this dataset is covered by any dy id producer
-        for name, dy_cfg in self.config_inst.x.dy_stitching.items():
+        for name, dy_cfg in dy_stitching.items():
             dataset_inst = dy_cfg["inclusive_dataset"]
             # the dataset is "covered" if its process is a subprocess of that of the dy dataset
             if dataset_inst.has_process(self.dataset_inst.processes.get_first()):

--- a/hbt/selection/jet.py
+++ b/hbt/selection/jet.py
@@ -9,7 +9,7 @@ from functools import reduce
 
 from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.selection.cms.jets import jet_veto_map
-from columnflow.selection.util import sorted_indices_from_mask
+from columnflow.columnar_util import sorted_indices_from_mask
 from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column
 

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -71,6 +71,16 @@ def IF_DATASET_IS_DY(
 
     return self.get() if func.dataset_inst.has_tag("is_dy") else None
 
+@deferred_column
+def IF_DATASET_IS_WJETS(
+    self: ArrayFunction.DeferredColumn,
+    func: ArrayFunction,
+) -> Any | set[Any]:
+    if getattr(func, "dataset_inst", None) is None:
+        return self.get()
+
+    return self.get() if func.dataset_inst.has_tag("is_w_lnu") else None
+
 
 def hash_events(arr: np.ndarray) -> np.ndarray:
     """


### PR DESCRIPTION
This PR generalizes the modules relevant for stitching samples in the analysis. The main differences are two-fold:

1. The process id producer is now more generalized to account for different methods of stitching. While this is probably overkill while we only stitch DY and W+jets samples, this might be useful in the future
2. the config entry has a more generalized structure:

```python
cfg.x.stitching = {
            "DATASET_TAG": {  # e.g. for DY datasets, this would be 'is_dy'
                "base_producer": PRODUCER_TO_USE,  # e.g. for DY, this would be `process_ids_dy`
                "info": {
                    "m50toinf": {
                        "inclusive_dataset": INCLUSIVE_DATASET,   # e.g. for DY, this would be `cfg.datasets.n.dy_m50toinf_amcatnlo`
                        "leaf_processes": [
                            # the following processes cover the full njet and pt phasespace
                            # for DY:
                            # procs.n.dy_m50toinf_0j,
                            # *(
                            #    procs.get(f"dy_m50toinf_{nj}j_pt{pt}")
                            #    for nj in [1, 2]
                            #    for pt in ["0to40", "40to100", "100to200", "200to400", "400to600", "600toinf"]
                            # ),
                            # procs.n.dy_m50toinf_ge3j,
                        ],
                    },
                }
            },
}
```

This way, we can configure all stitchings in one place. Tested with `w_lnu` and `dy` datasets