### PR TITLE
update dust paths after migration at DESY NAF

### DIFF
--- a/law_fs.cfg
+++ b/law_fs.cfg
@@ -43,7 +43,7 @@ base: &::xrootd_base
 #
 
 [local_fs_dust_mrieger]
-base: /nfs/dust/cms/user/riegerma/hh2bbtautau/hbt_store
+base: /data/dust/user/riegerma/hh2bbtautau/hbt_store
 default_dir_perm: 0o770
 default_file_perm: 0o660
 [local_fs_desy_mrieger]
@@ -62,7 +62,7 @@ cache_max_size: 50GB
 
 
 [local_fs_dust_pkeicher]
-base: /nfs/dust/cms/user/pkeicher/hh2bbtautau/hbt_store
+base: /data/dust/user/pkeicher/hh2bbtautau/hbt_store
 default_dir_perm: 0o770
 default_file_perm: 0o660
 [local_fs_desy_pkeicher]
@@ -81,7 +81,7 @@ cache_max_size: 50GB
 
 
 [local_fs_dust_bwieders]
-base: /nfs/dust/cms/user/wiedersb/hh2bbtautau/hbt_store
+base: /data/dust/user/wiedersb/hh2bbtautau/hbt_store
 default_dir_perm: 0o770
 default_file_perm: 0o660
 [local_fs_desy_bwieders]
@@ -100,7 +100,7 @@ cache_max_size: 50GB
 
 
 [local_fs_dust_nprouvos]
-base: /nfs/dust/cms/user/prouvost/hh2bbtautau/hbt_store
+base: /data/dust/user/prouvost/hh2bbtautau/hbt_store
 default_dir_perm: 0o770
 default_file_perm: 0o660
 [local_fs_desy_nprouvos]
@@ -119,7 +119,7 @@ cache_max_size: 50GB
 
 
 [local_fs_dust_aalvesan]
-base: /nfs/dust/cms/user/alvesand/hh2bbtautau/hbt_store
+base: /data/dust/user/alvesand/hh2bbtautau/hbt_store
 default_dir_perm: 0o770
 default_file_perm: 0o660
 [local_fs_desy_aalvesan]
@@ -153,7 +153,7 @@ cache_max_size: 50GB
 
 
 [local_fs_dust_roward]
-base: /nfs/dust/cms/user/wardrobe/hh2bbtautau/hbt_store
+base: /data/dust/user/wardrobe/hh2bbtautau/hbt_store
 default_dir_perm: 0o770
 default_file_perm: 0o660
 [local_fs_desy_roward]
@@ -172,7 +172,7 @@ cache_max_size: 50GB
 
 
 [local_fs_dust_pgadow]
-base: /nfs/dust/cms/user/pgadow/hh2bbtautau/hbt_store
+base: /data/dust/user/pgadow/hh2bbtautau/hbt_store
 default_dir_perm: 0o770
 default_file_perm: 0o660
 [local_fs_desy_pgadow]


### PR DESCRIPTION
The data structure at DESY NAF was updated on 20th January 2025

The maintenance will be used to migrate CMS to the new structure on DUST:
* user folders located at /data/dust/user
* group directories at /data/dust/group/cms

You can find additional details about the DUST migration here:
https://docs.desy.de/idaf/storage/dust/migration/

This pull requests updates the paths in `law_fs.cfg` from `/nfs/dust/cms/user/${USER}` to `/data/dust/user/${USER}`.