### PR TITLE
update gFTP path after NAF maintenance

### DIFF
--- a/law_fs.cfg
+++ b/law_fs.cfg
@@ -26,7 +26,7 @@ cache_max_size: 50GB
 
 [wlcg_fs_desy]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
 base: &::webdav_base
 base_filecopy: &::webdav_base
@@ -51,7 +51,7 @@ base: /pnfs/desy.de/cms/tier2/store/user/mrieger/hbt_store
 local_root_depth: 3
 [wlcg_fs_desy_mrieger]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/mrieger/hbt_store
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/mrieger/hbt_store
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/mrieger/hbt_store
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/mrieger/hbt_store
 base: &::xrootd_base
 create_file_dir: True
@@ -70,7 +70,7 @@ base: /pnfs/desy.de/cms/tier2/store/user/pkeicher/hbt_store
 local_root_depth: 3
 [wlcg_fs_desy_pkeicher]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/pkeicher/hbt_store
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/pkeicher/hbt_store
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/pkeicher/hbt_store
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/pkeicher/hbt_store
 base: &::xrootd_base
 create_file_dir: True
@@ -89,7 +89,7 @@ base: /pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
 local_root_depth: 3
 [wlcg_fs_desy_bwieders]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/bwieders/hbt_store
 base: &::xrootd_base
 create_file_dir: True
@@ -108,7 +108,7 @@ base: /pnfs/desy.de/cms/tier2/store/user/nprouvos/hbt_store
 local_root_depth: 3
 [wlcg_fs_desy_nprouvos]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/nprouvos/hbt_store
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/nprouvos/hbt_store
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/nprouvos/hbt_store
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/nprouvos/hbt_store
 base: &::webdav_base
 create_file_dir: True
@@ -127,7 +127,7 @@ base: /pnfs/desy.de/cms/tier2/store/user/aalvesan/hbt_store
 local_root_depth: 3
 [wlcg_fs_desy_aalvesan]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/aalvesan/hbt_store
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/aalvesan/hbt_store
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/aalvesan/hbt_store
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/aalvesan/hbt_store
 base: &::xrootd_base
 create_file_dir: True
@@ -142,7 +142,7 @@ base: /pnfs/desy.de/cms/tier2/store/user/anhaddad/hbt_store
 local_root_depth: 3
 [wlcg_fs_desy_anhaddad]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/anhaddad/hbt_store
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/anhaddad/hbt_store
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/anhaddad/hbt_store
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/anhaddad/hbt_store
 base: &::xrootd_base
 create_file_dir: True
@@ -161,7 +161,7 @@ base: /pnfs/desy.de/cms/tier2/store/user/roward/hbt_store
 local_root_depth: 3
 [wlcg_fs_desy_roward]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/roward/hbt_store
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/roward/hbt_store
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/roward/hbt_store
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/roward/hbt_store
 base: &::xrootd_base
 create_file_dir: True
@@ -180,7 +180,7 @@ base: /pnfs/desy.de/cms/tier2/store/user/pgadow/hbt_store
 local_root_depth: 3
 [wlcg_fs_desy_pgadow]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/pgadow/hbt_store
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/pgadow/hbt_store
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/pgadow/hbt_store
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/pgadow/hbt_store
 base: &::xrootd_base
 create_file_dir: True
@@ -199,7 +199,7 @@ cache_max_size: 50GB
 base: file:///pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v12/prod3
 [wlcg_fs_run3_2022_preEE_nano_uhh_v12]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v12/prod3
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v12/prod3
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v12/prod3
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v12/prod3
 base: &::xrootd_base
 use_cache: $CF_WLCG_USE_CACHE
@@ -213,7 +213,7 @@ cache_global_lock: True
 base: file:///pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v14/prod1
 [wlcg_fs_run3_2022_preEE_nano_uhh_v14]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v14/prod1
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v14/prod1
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v14/prod1
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/nprouvos/nanogen_store/MergeNano/config_22pre_v14/prod1
 base: &::xrootd_base
 use_cache: $CF_WLCG_USE_CACHE
@@ -227,7 +227,7 @@ cache_global_lock: True
 base: file:///pnfs/desy.de/cms/tier2/store/user/aalvesan/nanogen_store/MergeNano/config_22post_v14/prod1
 [wlcg_fs_run3_2022_postEE_nano_uhh_v14]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/aalvesan/nanogen_store/MergeNano/config_22post_v14/prod1
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/aalvesan/nanogen_store/MergeNano/config_22post_v14/prod1
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/aalvesan/nanogen_store/MergeNano/config_22post_v14/prod1
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/aalvesan/nanogen_store/MergeNano/config_22post_v14/prod1
 base: &::xrootd_base
 use_cache: $CF_WLCG_USE_CACHE
@@ -241,7 +241,7 @@ cache_global_lock: True
 base: file:///pnfs/desy.de/cms/tier2/store/user/bwieders/nanogen_store/MergeNano/config_23pre_v14/prod1
 [wlcg_fs_run3_2023_preBPix_nano_uhh_v14]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/bwieders/nanogen_store/MergeNano/config_23pre_v14/prod1
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/bwieders/nanogen_store/MergeNano/config_23pre_v14/prod1
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/bwieders/nanogen_store/MergeNano/config_23pre_v14/prod1
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/bwieders/nanogen_store/MergeNano/config_23pre_v14/prod1
 base: &::xrootd_base
 use_cache: $CF_WLCG_USE_CACHE
@@ -255,7 +255,7 @@ cache_global_lock: True
 base: file:///pnfs/desy.de/cms/tier2/store/user/roward/nanogen_store/MergeNano/config_23post_v14/prod1
 [wlcg_fs_run3_2023_postBPix_nano_uhh_v14]
 webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/roward/nanogen_store/MergeNano/config_23post_v14/prod1
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/roward/nanogen_store/MergeNano/config_23post_v14/prod1
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/roward/nanogen_store/MergeNano/config_23post_v14/prod1
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/roward/nanogen_store/MergeNano/config_23post_v14/prod1
 base: &::xrootd_base
 use_cache: $CF_WLCG_USE_CACHE


### PR DESCRIPTION
This pull request changes the default path for gFTP access.

The previous default `dcache-door-cms04.desy.de:2811 ` does not work anymore, after the doors have been rearranged during maintenance on 20th Jan 2025.

gFTP access does work with the load balancer alias:
[dcache-cms-gridftp.desy.de](http://dcache-cms-gridftp.desy.de/)