### PR TITLE
add HT variable

### DIFF
--- a/hbt/config/variables.py
+++ b/hbt/config/variables.py
@@ -49,9 +49,16 @@ def add_variables(config: od.Config) -> None:
         x_title="Number of HH b-tags",
         discrete_x=True,
     )
+    def build_ht(events):
+        objects = ak.concatenate([events.Electron * 1, events.Muon * 1, events.Tau * 1, events.Jet * 1], axis=1)[:, :]
+        objects_sum = objects.sum(axis=1)
+        return objects_sum.pt
+    build_ht.inputs = ["{Electron,Muon,Tau,Jet}.{pt,eta,phi,mass}"]
     add_variable(
         config,
         name="ht",
+        expression=partial(build_ht),
+        aux={"inputs": build_ht.inputs},
         binning=[0, 80, 120, 160, 200, 240, 280, 320, 400, 500, 600, 800],
         unit="GeV",
         x_title="HT",


### PR DESCRIPTION
This pull request adds the HT variable (can be used in emu control region to assess top mis-modelling).

HT = sum of all electron, muon, tau, jet transverse momenta