### PR TITLE
Introduce TF evaluator.

### DIFF
--- a/hbt/ml/tf_evaluator.py
+++ b/hbt/ml/tf_evaluator.py
@@ -1,0 +1,225 @@
+# coding: utf-8
+
+"""
+Generic interface for loading and evaluating TensorFlow models in a separate process.
+Data exchange is handled through multiprocessing pipes.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import pathlib
+from multiprocessing import Process, Pipe
+from multiprocessing.connection import Connection
+from dataclasses import dataclass
+from typing import Any
+
+
+STOP_SIGNAL = "STOP"
+
+
+class TFEvaluator:
+    """
+    TensorFlow model evaluator that runs in a separate process with support for multiple models.
+
+    .. code-block:: python
+
+        evaluator = TFEvaluator()
+        evaluator.add_model("model_name", "path/to/model")
+        with evaluator:
+            result = evaluator("model_name", input_data)
+    """
+
+    @dataclass
+    class Model:
+        name: str
+        path: str
+        pipe: Connection | None = None
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._models: dict[str, TFEvaluator.Model] = {}
+        self._p: Process | None = None
+
+        self.delay = 0.2
+        self.silent = False
+
+    def __enter__(self) -> TFEvaluator:
+        self.start()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.stop()
+
+    def __del__(self) -> None:
+        self.stop()
+
+    def __call__(self, *args, **kwargs) -> Any:
+        return self.evaluate(*args, **kwargs)
+
+    @property
+    def running(self) -> bool:
+        return self._p is not None
+
+    def add_model(self, name: str, path: str | pathlib.Path) -> None:
+        if self.running:
+            raise ValueError("cannot add models while running")
+        if name in self._models:
+            raise ValueError(f"model with name '{name}' already exists")
+
+        # normalize path
+        path = str(path)
+        path = os.path.expandvars(os.path.expanduser(path))
+        path = os.path.abspath(os.path.abspath(path))
+
+        # add it
+        self._models[name] = TFEvaluator.Model(name=name, path=path)
+
+    def start(self) -> None:
+        if self.running:
+            raise ValueError("process already started")
+
+        # build the subprocess config
+        config = []
+        for model in self._models.values():
+            parent_pipe, child_pipe = Pipe()
+            model.pipe = parent_pipe
+            config.append({"name": model.name, "path": model.path, "pipe": child_pipe})
+
+        # create and start the process
+        self._p = Process(
+            target=_tf_evaluate,
+            args=(config,),
+            kwargs={"delay": self.delay, "silent": self.silent},
+        )
+        self._p.start()
+
+    def evaluate(self, name: str, *args, **kwargs) -> Any:
+        if not self.running:
+            raise ValueError("process not started")
+
+        # get the model
+        if name not in self._models:
+            raise ValueError(f"model with name '{name}' does not exist")
+        model = self._models[name]
+
+        # evaluate and send back result
+        model.pipe.send((args, kwargs))  # type: ignore[union-attr]
+        return model.pipe.recv()  # type: ignore[union-attr]
+
+    def stop(self, timeout: int | float = 5) -> None:
+        # stop and remove model pipes
+        for model in self._models.values():
+            if model.pipe is not None:
+                model.pipe.send(STOP_SIGNAL)
+                model.pipe.close()
+                model.pipe = None
+
+        # nothing to do when not running
+        if not self.running:
+            return
+
+        # join to wait for normal termination
+        if self._p.is_alive():
+            self._p.join(timeout)
+
+            # kill if still alive
+            if self._p.is_alive():
+                self._p.kill()
+
+        # reset
+        self._p = None
+
+
+def _tf_evaluate(
+    config: list[dict[str, Any]],
+    /,
+    *,
+    delay: int | float = 0.2,
+    silent: bool = False,
+) -> None:
+    _print = (lambda *args, **kwargs: None) if silent else print
+
+    _print("importing tensorflow ...")
+    import numpy as np
+    import tensorflow as tf  # type: ignore[import-not-found,import-untyped]
+    _print("done")
+
+    @dataclass
+    class Model:
+        name: str
+        path: str
+        pipe: Connection
+        model: Any = None
+
+        @classmethod
+        def new(cls, config: dict, /) -> Model:
+            for attr in ("name", "path", "pipe"):
+                if attr not in config:
+                    raise ValueError(f"missing field '{attr}' in model config")
+            if not os.path.exists(config["path"]):
+                raise FileNotFoundError(f"model file '{config['path']}' does not exist")
+            if not isinstance(config["pipe"], Connection):
+                raise TypeError(f"'pipe' {config['pipe']} not of type '{Connection}'")
+            return cls(name=config["name"], path=config["path"], pipe=config["pipe"])
+
+        def load(self) -> None:
+            _print(f"loading model '{self.name}' from {self.path} ...")
+            self.model = tf.saved_model.load(self.path)
+            _print("done")
+
+        def evaluate(self, *args, **kwargs) -> np.ndarray:
+            return self.model(*args, **kwargs).numpy()
+
+        def clear(self) -> None:
+            _print(f"clearing model '{self.name}'")
+            self.model = None
+            self.pipe.close()
+
+    # convert to model objects
+    models = [Model.new(item) for item in config]
+
+    # load model objects
+    for model in models:
+        model.load()
+
+    # helper for gracefully shutting down
+    def shutdown() -> None:
+        for model in models:
+            model.clear()
+        models.clear()
+
+    # start loop listening for data
+    while models:
+        remove_models: list[int] = []
+        for i, model in enumerate(models):
+            # skip if there is no data to process
+            if not model.pipe.poll():
+                continue
+
+            # get data and process
+            data = model.pipe.recv()
+            if isinstance(data, tuple) and len(data) == 2:
+                # evaluate
+                try:
+                    args, kwargs = data
+                    result = model.evaluate(*args, **kwargs)
+                except:
+                    shutdown()
+                    raise
+                # send back result
+                model.pipe.send(result)
+
+            elif data == STOP_SIGNAL:
+                # remove model
+                model.clear()
+                remove_models.append(i)
+
+            else:
+                raise ValueError(f"unexpected data type {type(data)}")
+
+        # reduce models and sleep
+        models = [model for i, model in enumerate(models) if i not in remove_models]
+        time.sleep(delay)

--- a/hbt/production/hhbtag.py
+++ b/hbt/production/hhbtag.py
@@ -169,6 +169,13 @@ def hhbtag_setup(
     repo_dir = bundle.files_dir.child("hh-btag-repo", type="d")
     arc.load(repo_dir, formatter="tar")
 
+    # setup the evaluator
+    model_dir = repo_dir.child("hh-btag-master/models")
+    model_path = f"HHbtag_{self.hhbtag_version}_par"
+    self.evaluator = TFEvaluator()
+    self.evaluator.add_model("hhbtag_even", model_dir.child(f"{model_path}_0").path)
+    self.evaluator.add_model("hhbtag_odd", model_dir.child(f"{model_path}_1").path)
+
     # get the version of the external file
     self.hhbtag_version = self.config_inst.x.external_files["hh_btag_repo"][1]
 
@@ -215,12 +222,7 @@ def hhbtag_setup(
             f"{self.config_inst.x.met_name}",
         )
 
-    # start the TF evaluator
-    model_dir = repo_dir.child("hh-btag-master/models")
-    model_path = f"HHbtag_{self.hhbtag_version}_par"
-    self.evaluator = TFEvaluator()
-    self.evaluator.add_model("hhbtag_even", model_dir.child(f"{model_path}_0").path)
-    self.evaluator.add_model("hhbtag_odd", model_dir.child(f"{model_path}_1").path)
+    # start the evaluator
     self.evaluator.start()
 
 

--- a/hbt/production/hhbtag.py
+++ b/hbt/production/hhbtag.py
@@ -101,11 +101,11 @@ def hhbtag(
     even_mask = ak.to_numpy((events[event_mask].event % 2) == 0)
     if ak.sum(even_mask):
         input_features_even = split(even_mask)
-        scores_even = self.hhbtag_model_even(input_features_even).numpy()
+        scores_even = self.evaluator("hhbtag_even", input_features_even)
         scores[even_mask] = scores_even
     if ak.sum(~even_mask):
         input_features_odd = split(~even_mask)
-        scores_odd = self.hhbtag_model_odd(input_features_odd).numpy()
+        scores_odd = self.evaluator("hhbtag_odd", input_features_odd)
         scores[~even_mask] = scores_odd
 
     # remove the scores of padded jets
@@ -159,12 +159,7 @@ def hhbtag_setup(
     """
     Sets up the two HHBtag TF models.
     """
-    import os
-    os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
-    import tensorflow as tf
-
-    tf.config.threading.set_inter_op_parallelism_threads(1)
-    tf.config.threading.set_intra_op_parallelism_threads(1)
+    from hbt.ml.tf_evaluator import TFEvaluator
 
     # unpack the external files bundle, create a subdiretory and unpack the hhbtag repo in it
     bundle = reqs["external_files"]
@@ -176,14 +171,6 @@ def hhbtag_setup(
 
     # get the version of the external file
     self.hhbtag_version = self.config_inst.x.external_files["hh_btag_repo"][1]
-
-    # define the model path
-    model_dir = repo_dir.child("hh-btag-master/models")
-    model_path = f"HHbtag_{self.hhbtag_version}_par"
-    # save both models (even and odd event numbers)
-    with task.publish_step("loading hhbtag models ..."):
-        self.hhbtag_model_even = tf.saved_model.load(model_dir.child(f"{model_path}_0").path)
-        self.hhbtag_model_odd = tf.saved_model.load(model_dir.child(f"{model_path}_1").path)
 
     # prepare mappings for the HHBtag model
     # (see links above for mapping information)
@@ -227,3 +214,20 @@ def hhbtag_setup(
             f"hhbtag model {self.hhbtag_version} uses {hhbtag_met_name}, but config requests "
             f"{self.config_inst.x.met_name}",
         )
+
+    # start the TF evaluator
+    model_dir = repo_dir.child("hh-btag-master/models")
+    model_path = f"HHbtag_{self.hhbtag_version}_par"
+    self.evaluator = TFEvaluator()
+    self.evaluator.add_model("hhbtag_even", model_dir.child(f"{model_path}_0").path)
+    self.evaluator.add_model("hhbtag_odd", model_dir.child(f"{model_path}_1").path)
+    self.evaluator.start()
+
+
+@hhbtag.teardown
+def hhbtag_teardown(self: Producer) -> None:
+    """
+    Stops the TF evaluator.
+    """
+    if (evaluator := getattr(self, "evaluator", None)) is not None:
+        evaluator.stop()

--- a/hbt/production/res_networks.py
+++ b/hbt/production/res_networks.py
@@ -381,6 +381,15 @@ def _res_dnn_evaluation_setup(
     self.evaluator.start()
 
 
+@_res_dnn_evaluation.teardown
+def _res_dnn_evaluation_teardown(self: Producer) -> None:
+    """
+    Stops the TF evaluator.
+    """
+    if (evaluator := getattr(self, "evaluator", None)) is not None:
+        evaluator.stop()
+
+
 #
 # parameterized network
 # trained with Radion (spin 0) and Graviton (spin 2) samples up to mX = 3000 GeV in all run 2 eras

--- a/hbt/production/res_networks.py
+++ b/hbt/production/res_networks.py
@@ -66,8 +66,6 @@ def _res_dnn_evaluation(
     correct order can be found in the tautauNN repo:
     https://github.com/uhh-cms/tautauNN/blob/f1ca194/evaluation/interface.py#L67
     """
-    import tensorflow as tf
-
     # ensure coffea behavior
     events = self[attach_coffea_behavior](
         events,
@@ -253,9 +251,10 @@ def _res_dnn_evaluation(
     ]
 
     # evaluate the model
-    scores = self.res_model(
-        cont_input=tf.concat(continous_inputs, axis=1),
-        cat_input=tf.concat(categorical_inputs, axis=1),
+    scores = self.evaluator(
+        "res",
+        cont_input=np.concatenate(continous_inputs, axis=1),
+        cat_input=np.concatenate(categorical_inputs, axis=1),
     )["hbt_ensemble"].numpy()
 
     # in very rare cases (1 in 25k), the network output can be none, likely for numerical reasons,
@@ -298,17 +297,11 @@ def _res_dnn_evaluation_setup(
     reqs: dict[str, DotDict[str, Any]],
     **kwargs,
 ) -> None:
-    import os
-    os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
-    import tensorflow as tf
+    from hbt.ml.tf_evaluator import TFEvaluator
 
     # some checks
     if not isinstance(self.parametrized, bool):
         raise AttributeError("'parametrized' must be set in the producer configuration")
-
-    # constrain tf to use only one core
-    tf.config.threading.set_inter_op_parallelism_threads(1)
-    tf.config.threading.set_intra_op_parallelism_threads(1)
 
     # unpack the model archive
     bundle = reqs["external_files"]
@@ -316,10 +309,9 @@ def _res_dnn_evaluation_setup(
     model_dir = bundle.files_dir.child(self.cls_name, type="d")
     getattr(bundle.files, self.cls_name).load(model_dir, formatter="tar")
 
-    # load the model
-    with task.publish_step(f"loading resonant model '{self.cls_name}' ..."):
-        saved_model = tf.saved_model.load(model_dir.child("model_fold0").abspath)
-        self.res_model = saved_model.signatures["serving_default"]
+    # setup the evaluator
+    self.evaluator = TFEvaluator()
+    self.evaluator.add_model("res", model_dir.child("model_fold0").abspath, serving_key="serving_default")
 
     # categorical values handled by the network
     # (names and values from training code that was aligned to KLUB notation)
@@ -359,6 +351,9 @@ def _res_dnn_evaluation_setup(
         (2023, ""): 3,
         (2023, "BPix"): 3,
     }[(self.config_inst.campaign.x.year, self.config_inst.campaign.x.postfix)]
+
+    # start the evaluator
+    self.evaluator.start()
 
 
 #

--- a/law.cfg
+++ b/law.cfg
@@ -81,7 +81,7 @@ chunked_io_debug: False
 [resources]
 
 # default selection with hhbtag requires more memory
-cf.{Select,Reduce}Events__sel_default: htcondor_memory=6GB, crab_memory=5000MB
+cf.{Select,Reduce}Events__sel_default: htcondor_memory=5.95GB, crab_memory=5000MB
 
 
 #


### PR DESCRIPTION
This PR adds a new object called TFEvaluator.

It is essentially just a glorified subprocess that allows encapsulating TF model lifetimes and evaluating calls, and consequently an easy way to free up resources upon termination.

I ported the hhbtag as well as the res net evaluation.