### PR TITLE
Update 2022post to include period G luminosity

### DIFF
--- a/hbt/config/configs_hbt.py
+++ b/hbt/config/configs_hbt.py
@@ -689,7 +689,7 @@ def add_config(
             "lumi_13p6TeV_correlated": 0.014j,
         })
     elif year == 2022 and campaign.has_tag("postEE"):
-        cfg.x.luminosity = Number(23_588.8567, {
+        cfg.x.luminosity = Number(26_671.6097, {
             "lumi_13p6TeV_correlated": 0.014j,
         })
     elif year == 2023 and campaign.has_tag("preBPix"):


### PR DESCRIPTION
Updates the luminosity of the 2022post dataset to include the 3.1 fb-1 from period G, increasing the total from 23.6 fb-1 to 26.7 fb-1. 

Validation plots showing 2022post (using prod9) with this update are here, where in particular the ttbar data/MC agreement is much improved: https://roward.web.cern.ch/HHbbtautau/analysis_hbt/prod9/22post_v14/plots_periodEFG_200623_allWeights/ 
Plots with the previous luminosity (accounting for E and F only) are here: https://roward.web.cern.ch/HHbbtautau/analysis_hbt/prod9/22post_v14/plots_200619_allWeights/

Luminosity for period G was calculated with brilcalc. Below is a copy of the script, based on CClub [issue #49](https://gitlab.cern.ch/cclubbtautau/AnalysisCore/-/issues/49), and the corresponding outputs:

```
export PATH=$HOME/.local/bin:/cvmfs/cms-bril.cern.ch/brilconda310/bin:$PATH
pip install --user --upgrade brilws

normtag_bril='/cvmfs/cms-bril.cern.ch/cms-lumi-pog/Normtags/normtag_PHYSICS.json'
golden_json22='/eos/user/c/cmsdqm/www/CAF/certification/Collisions22/Cert_Collisions2022_355100_362760_Golden.json'
golden_json23='/eos/user/c/cmsdqm/www/CAF/certification/Collisions23/Cert_Collisions2023_366442_370790_Golden.json'

#Run2022G                                                                                                                                                                                                          
brilcalc lumi --begin 362350 --end 362760 -u /pb -b "STABLE BEAMS" --normtag "${normtag_bril}" -i "${golden_json22}"
#+-------+------+-------+-------+-------------------+------------------+                                                                                                                                           
#| nfill | nrun | nls   | ncms  | totdelivered(/pb) | totrecorded(/pb) |                                                                                                                                           
#+-------+------+-------+-------+-------------------+------------------+                                                                                                                                           
#| 7     | 21   | 8242  | 8242  | 3241.980255124    | 3082.753035626   |                                                                                                                                           
#+-------+------+-------+-------+-------------------+------------------+                                                                                                                                           

#Run2022EFG                                                                                                                                                                                                        
brilcalc lumi --begin 359022 --end 362760 -u /pb -b "STABLE BEAMS" --normtag "${normtag_bril}" -i "${golden_json22}"
#+-------+------+-------+-------+-------------------+------------------+                                                                                                                                           
#| nfill | nrun | nls   | ncms  | totdelivered(/pb) | totrecorded(/pb) |                                                                                                                                           
#+-------+------+-------+-------+-------------------+------------------+                                                                                                                                           
#| 77    | 190  | 81529 | 81529 | 27985.222049022   | 26671.609707229  |                                                                                                                                           
#+-------+------+-------+-------+-------------------+------------------+                                                                                                                                           
```

These values are also in agreement with the PPD 2022 summary slide: https://docs.google.com/presentation/d/1F4ndU7DBcyvrEEyLfYqb29NGkBPs20EAnBxe_l7AEII/edit?slide=id.g289f499aa6b_2_52#slide=id.g289f499aa6b_2_52 