### PR TITLE
DY stitching

### DIFF
--- a/hbt/calibration/default.py
+++ b/hbt/calibration/default.py
@@ -18,7 +18,7 @@ from columnflow.production.cms.seeds import (
 )
 from columnflow.util import maybe_import
 
-from hbt.util import IF_RUN_2, IF_RUN_3, IF_DATA, IF_MC
+from hbt.util import IF_RUN_3, IF_DATA, IF_MC
 
 ak = maybe_import("awkward")
 
@@ -167,9 +167,7 @@ def default_init(self: Calibrator, **kwargs) -> None:
             "with_uncertainties": False,
         })
         # derive met_phi calibrator (currently only used in run 2)
-        add_calib_cls("met_phi", met_phi, cls_dict={
-            "met_name": met_name,
-        })
+        add_calib_cls("met_phi", met_phi)
 
         # change the flag
         self.config_inst.set_aux(flag, True)
@@ -199,7 +197,7 @@ def default_init(self: Calibrator, **kwargs) -> None:
         IF_RUN_3(self.eec_nominal_cls),
         IF_RUN_3(self.deterministic_eer_full_cls),
         IF_RUN_3(self.deterministic_eer_nominal_cls),
-        IF_RUN_2(self.met_phi_cls),
+        self.met_phi_cls,
     }
     self.uses |= derived_calibrators
     self.produces |= derived_calibrators

--- a/hbt/config/configs_hbt.py
+++ b/hbt/config/configs_hbt.py
@@ -727,10 +727,14 @@ def add_config(
     else:
         assert False
 
-    # name of the MET phi correction set
-    # (used in the met_phi calibrator)
-    if run == 2:
-        cfg.x.met_phi_correction_set = r"{variable}_metphicorr_pfmet_{data_source}"
+    # met phi correction config
+    from columnflow.calibration.cms.met import METPhiConfig
+    cfg.x.met_phi_correction = METPhiConfig(
+        met_name=cfg.x.met_name,
+        correction_set="met_xy_corrections" if run == 3 else r"{variable}_metphicorr_pfmet_{data_source}",
+        keep_uncorrected=True,
+        variable_config={"phi": ("phi",)},  # not added pt here, just interested in phi correction
+    )
 
     ################################################################################################
     # jet settings
@@ -1426,10 +1430,10 @@ def add_config(
         if year == 2016:
             json_postfix = f"{'pre' if campaign.has_tag('preVFP') else 'post'}VFP"
         json_pog_era = f"{year}{json_postfix}_UL"
-        json_mirror = "/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-b7a48c75"
+        json_mirror = "/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-406118ec"
     elif run == 3:
         json_pog_era = f"{year}_Summer{year2}{campaign.x.postfix}"
-        json_mirror = "/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-b7a48c75"
+        json_mirror = "/afs/cern.ch/user/m/mrieger/public/mirrors/jsonpog-integration-406118ec"
         trigger_json_mirror = "https://gitlab.cern.ch/cclubbtautau/AnalysisCore/-/archive/59ae66c4a39d3e54afad5733895c33b1fb511c47/AnalysisCore-59ae66c4a39d3e54afad5733895c33b1fb511c47.tar.gz"  # noqa: E501
         campaign_tag = ""
         for tag in ("preEE", "postEE", "preBPix", "postBPix"):
@@ -1503,7 +1507,8 @@ def add_config(
         add_external("jet_id", (f"{json_mirror}/POG/JME/{json_pog_era}/jetid.json.gz", "v1"))
         # muon scale factors
         add_external("muon_sf", (f"{json_mirror}/POG/MUO/{json_pog_era}/muon_Z.json.gz", "v1"))
-
+        # met phi correction
+        add_external("met_phi_corr", (f"{json_mirror}/POG/JME/{json_pog_era}/met_xyCorrections_{year}_{year}{campaign.x.postfix}.json.gz", "v1"))  # noqa: E501
         # electron scale factors
         add_external("electron_sf", (f"{json_mirror}/POG/EGM/{json_pog_era}/electron.json.gz", "v1"))
         # electron energy correction and smearing

--- a/hbt/config/configs_hbt.py
+++ b/hbt/config/configs_hbt.py
@@ -295,7 +295,7 @@ def add_config(
             # disabled for now
             # "dy_tautau_m50toinf_0j_filtered_amcatnlo",
             # "dy_tautau_m50toinf_1j_filtered_amcatnlo",
-            # # "dy_tautau_m50toinf_2j_filtered_amcatnlo",
+            # "dy_tautau_m50toinf_2j_filtered_amcatnlo",
         ]),
         *if_era(year=2023, tag="preBPix", values=[
             # "dy_tautau_m50toinf_0j_amcatnlo",
@@ -309,7 +309,7 @@ def add_config(
         *if_era(year=2023, tag="postBPix", values=[
             "dy_tautau_m50toinf_0j_amcatnlo",
             "dy_tautau_m50toinf_1j_amcatnlo",
-            # "dy_tautau_m50toinf_2j_amcatnlo",
+            "dy_tautau_m50toinf_2j_amcatnlo",
             # disabled for now
             # "dy_tautau_m50toinf_0j_filtered_amcatnlo",
             # "dy_tautau_m50toinf_1j_filtered_amcatnlo",

--- a/hbt/config/configs_hbt.py
+++ b/hbt/config/configs_hbt.py
@@ -278,13 +278,16 @@ def add_config(
         "dy_m50toinf_2j_pt200to400_amcatnlo",
         "dy_m50toinf_2j_pt400to600_amcatnlo",
         "dy_m50toinf_2j_pt600toinf_amcatnlo",
-        # specific tau filtered datasets
+        # specific tautau datasets with pythia bug fix
+        *if_era(year=2022, tag="preEE", values=[
+            "dy_tautau_m50toinf_0j_amcatnlo",
+            "dy_tautau_m50toinf_1j_amcatnlo",
+            "dy_tautau_m50toinf_2j_amcatnlo",
+        ]),
         # "dy_tautau_m50toinf_0j_amcatnlo",
-        # # TODO: still missing for 22post
         # *if_not_era(year=2022, tag="postEE", values=[
         #     "dy_tautau_m50toinf_1j_amcatnlo",
         # ]),
-        # # TODO: missing for 22post and 23pre
         # *if_era(year=2022, tag="preEE", values=["dy_tautau_m50toinf_2j_amcatnlo"]),
         # *if_era(year=2023, tag="postBPix", values=["dy_tautau_m50toinf_2j_amcatnlo"]),
 
@@ -427,10 +430,10 @@ def add_config(
                 dataset.add_tag("dy_powheg")
             # tags for advanced, lepton based stitching in amcatnlo
             # (not adding the tags will result in the default selection and stitching behavior)
-            # if dataset.name.endswith("_amcatnlo"):
-            #     dataset.add_tag("dy_lep_amcatnlo")  # trigges the lepton channel stitching in the default selector
-            #     if re.match(r"^dy_m50toinf_(|\dj_(|pt.+_))amcatnlo$", dataset.name):
-            #         dataset.add_tag("dy_drop_tautau")  # drops tautau events in the default selector
+            if dataset.name.endswith("_amcatnlo"):
+                dataset.add_tag("dy_lep_amcatnlo")  # trigges the lepton channel stitching in the default selector
+                if re.match(r"^dy_m50toinf_(|\dj_(|pt.+_))amcatnlo$", dataset.name):
+                    dataset.add_tag("dy_drop_tautau")  # drops tautau events in the default selector
         if (
             re.match(r"^dy_m50toinf_\dj_(|pt.+_)amcatnlo$", dataset.name) or
             re.match(r"^dy_tautau_m50toinf_\dj_amcatnlo$", dataset.name) or
@@ -530,6 +533,14 @@ def add_config(
             "h",
             "ewk",
         ]),
+        "dy_split": [
+            "dy_m50toinf_0j",
+            "dy_m50toinf_1j_pt0to40", "dy_m50toinf_1j_pt40to100", "dy_m50toinf_1j_pt100to200",
+            "dy_m50toinf_1j_pt200to400", "dy_m50toinf_1j_pt400to600", "dy_m50toinf_1j_pt600toinf",
+            "dy_m50toinf_2j_pt0to40", "dy_m50toinf_2j_pt40to100", "dy_m50toinf_2j_pt100to200",
+            "dy_m50toinf_2j_pt200to400", "dy_m50toinf_2j_pt400to600", "dy_m50toinf_2j_pt600toinf",
+            "dy_m50toinf_ge3j",
+        ],
         "sm_ggf": (sm_ggf_group := ["hh_ggf_hbb_htt_kl1_kt1", *backgrounds]),
         "sm": (sm_group := ["hh_ggf_hbb_htt_kl1_kt1", "hh_vbf_hbb_htt_kv1_k2v1_kl1", *backgrounds]),
         "sm_ggf_data": ["data"] + sm_ggf_group,

--- a/hbt/config/configs_hbt.py
+++ b/hbt/config/configs_hbt.py
@@ -283,13 +283,38 @@ def add_config(
             "dy_tautau_m50toinf_0j_amcatnlo",
             "dy_tautau_m50toinf_1j_amcatnlo",
             "dy_tautau_m50toinf_2j_amcatnlo",
+            # disabled for now
+            # "dy_tautau_m50toinf_0j_filtered_amcatnlo",
+            # "dy_tautau_m50toinf_1j_filtered_amcatnlo",
+            # "dy_tautau_m50toinf_2j_filtered_amcatnlo",
         ]),
-        # "dy_tautau_m50toinf_0j_amcatnlo",
-        # *if_not_era(year=2022, tag="postEE", values=[
-        #     "dy_tautau_m50toinf_1j_amcatnlo",
-        # ]),
-        # *if_era(year=2022, tag="preEE", values=["dy_tautau_m50toinf_2j_amcatnlo"]),
-        # *if_era(year=2023, tag="postBPix", values=["dy_tautau_m50toinf_2j_amcatnlo"]),
+        *if_era(year=2022, tag="postEE", values=[
+            # "dy_tautau_m50toinf_0j_amcatnlo",
+            # "dy_tautau_m50toinf_1j_amcatnlo",
+            # "dy_tautau_m50toinf_2j_amcatnlo",
+            # disabled for now
+            # "dy_tautau_m50toinf_0j_filtered_amcatnlo",
+            # "dy_tautau_m50toinf_1j_filtered_amcatnlo",
+            # # "dy_tautau_m50toinf_2j_filtered_amcatnlo",
+        ]),
+        *if_era(year=2023, tag="preBPix", values=[
+            # "dy_tautau_m50toinf_0j_amcatnlo",
+            # "dy_tautau_m50toinf_1j_amcatnlo",
+            # "dy_tautau_m50toinf_2j_amcatnlo",
+            # disabled for now
+            # "dy_tautau_m50toinf_0j_filtered_amcatnlo",
+            # "dy_tautau_m50toinf_1j_filtered_amcatnlo",
+            # "dy_tautau_m50toinf_2j_filtered_amcatnlo",
+        ]),
+        *if_era(year=2023, tag="postBPix", values=[
+            "dy_tautau_m50toinf_0j_amcatnlo",
+            "dy_tautau_m50toinf_1j_amcatnlo",
+            # "dy_tautau_m50toinf_2j_amcatnlo",
+            # disabled for now
+            # "dy_tautau_m50toinf_0j_filtered_amcatnlo",
+            # "dy_tautau_m50toinf_1j_filtered_amcatnlo",
+            # "dy_tautau_m50toinf_2j_filtered_amcatnlo",
+        ]),
 
         # dy, powheg
         # *if_era(year=2022, values=["dy_ee_m50toinf_powheg"]),  # 50toinf only available in 2022, requires stitching
@@ -436,7 +461,7 @@ def add_config(
                     dataset.add_tag("dy_drop_tautau")  # drops tautau events in the default selector
         if (
             re.match(r"^dy_m50toinf_\dj_(|pt.+_)amcatnlo$", dataset.name) or
-            re.match(r"^dy_tautau_m50toinf_\dj_amcatnlo$", dataset.name) or
+            re.match(r"^dy_tautau_m50toinf_\dj_(|filtered_)amcatnlo$", dataset.name) or
             (
                 "dy_ee_m50toinf_powheg" in cfg.datasets and
                 re.match(r"^dy_ee_m.*_powheg$", dataset.name) and

--- a/hbt/config/styles.py
+++ b/hbt/config/styles.py
@@ -7,6 +7,7 @@ Style definitions.
 from __future__ import annotations
 
 import re
+import random
 from collections import defaultdict
 
 import order as od
@@ -194,6 +195,21 @@ def stylize_processes(config: od.Config) -> None:
 
     if (p := config.get_process("qcd", default=None)):
         p.color1 = cfg.x.colors.red
+
+    seed_orig = random.seed()
+    random.seed(1)
+    for i, n in enumerate([
+        "dy_m50toinf_0j",
+        "dy_m50toinf_1j_pt0to40", "dy_m50toinf_1j_pt40to100", "dy_m50toinf_1j_pt100to200",
+        "dy_m50toinf_1j_pt200to400", "dy_m50toinf_1j_pt400to600", "dy_m50toinf_1j_pt600toinf",
+        "dy_m50toinf_2j_pt0to40", "dy_m50toinf_2j_pt40to100", "dy_m50toinf_2j_pt100to200",
+        "dy_m50toinf_2j_pt200to400", "dy_m50toinf_2j_pt400to600", "dy_m50toinf_2j_pt600toinf",
+        "dy_m50toinf_ge3j",
+    ]):
+        if (p := config.get_process(n, default=None)):
+            # random color with values in the range 0 to 255
+            p.color1 = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
+    random.seed(seed_orig)
 
 
 def legend_entries_per_column(ax, handles: list, labels: list, n_cols: int) -> list[int]:

--- a/hbt/histogramming/default.py
+++ b/hbt/histogramming/default.py
@@ -64,6 +64,7 @@ no_weight = default.derive("no_weight", cls_dict={
     "drop_weights": {"*"},
 })
 
+# weight producer for cross checking histograms without stitching
 normalization_inclusive = default.derive("normalization_inclusive", cls_dict={
     "drop_weights": {"normalization_weight"},
 })

--- a/hbt/production/default.py
+++ b/hbt/production/default.py
@@ -5,7 +5,6 @@ Wrappers for some default sets of producers.
 """
 
 from columnflow.production import Producer, producer
-from columnflow.production.normalization import stitched_normalization_weights
 from columnflow.production.categories import category_ids
 from columnflow.production.cms.electron import electron_weights
 from columnflow.production.cms.muon import muon_weights
@@ -15,7 +14,8 @@ from columnflow.util import maybe_import
 from columnflow.columnar_util import attach_coffea_behavior, default_coffea_collections
 
 from hbt.production.weights import (
-    normalized_pu_weight, normalized_pdf_weight, normalized_murmuf_weight, normalized_ps_weights,
+    stitched_normalization_weights, normalized_pu_weight, normalized_pdf_weight,  # TODO: add back _dy_tautau_drop
+    normalized_murmuf_weight, normalized_ps_weights,
 )
 from hbt.production.btag import normalized_btag_weights_deepjet, normalized_btag_weights_pnet
 from hbt.production.tau import tau_weights

--- a/hbt/production/default.py
+++ b/hbt/production/default.py
@@ -14,7 +14,7 @@ from columnflow.util import maybe_import
 from columnflow.columnar_util import attach_coffea_behavior, default_coffea_collections
 
 from hbt.production.weights import (
-    stitched_normalization_weights, normalized_pu_weight, normalized_pdf_weight,  # TODO: add back _dy_tautau_drop
+    stitched_normalization_weights_dy_tautau_drop, normalized_pu_weight, normalized_pdf_weight,
     normalized_murmuf_weight, normalized_ps_weights,
 )
 from hbt.production.btag import normalized_btag_weights_deepjet, normalized_btag_weights_pnet
@@ -30,13 +30,13 @@ top_pt_weight = cf_top_pt_weight.derive("top_pt_weight", cls_dict={"require_data
 
 @producer(
     uses={
-        category_ids, stitched_normalization_weights, normalized_pu_weight, normalized_ps_weights,
+        category_ids, stitched_normalization_weights_dy_tautau_drop, normalized_pu_weight, normalized_ps_weights,
         normalized_btag_weights_deepjet, IF_RUN_3(normalized_btag_weights_pnet),
         IF_DATASET_HAS_LHE_WEIGHTS(normalized_pdf_weight, normalized_murmuf_weight),
         # weight producers added dynamically if produce_weights is set
     },
     produces={
-        category_ids, stitched_normalization_weights, normalized_pu_weight, normalized_ps_weights,
+        category_ids, stitched_normalization_weights_dy_tautau_drop, normalized_pu_weight, normalized_ps_weights,
         normalized_btag_weights_deepjet, IF_RUN_3(normalized_btag_weights_pnet),
         IF_DATASET_HAS_LHE_WEIGHTS(normalized_pdf_weight, normalized_murmuf_weight),
         # weight producers added dynamically if produce_weights is set
@@ -55,7 +55,7 @@ def default(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     # mc-only weights
     if self.dataset_inst.is_mc:
         # normalization weights
-        events = self[stitched_normalization_weights](events, **kwargs)
+        events = self[stitched_normalization_weights_dy_tautau_drop](events, **kwargs)
 
         # normalized pdf weight
         if self.has_dep(normalized_pdf_weight):

--- a/hbt/production/hhbtag.py
+++ b/hbt/production/hhbtag.py
@@ -46,14 +46,13 @@ def hhbtag(
         (ak.sum(jet_mask, axis=1) >= 2)
     )
 
-    # ordering by decreasing btagscore and then pt
+    # ordering by decreasing btag score, then pt
     f = 10**(np.ceil(np.log10(ak.max(events.Jet.pt))) + 2)
     tagging_key = (events.Jet.btagDeepFlavB if self.hhbtag_version == "v2" else events.Jet.btagPNetB)
     jet_sorting_key = tagging_key * f + events.Jet.pt
     jet_sorting_indices = ak.argsort(jet_sorting_key, axis=-1, ascending=False)
-
     # back transformations for the saving of the scores
-    back_transformation = ak.argsort(jet_sorting_indices)
+    jet_unsorting_indices = ak.argsort(jet_sorting_indices)
 
     # prepare objects
     n_jets_max = 10
@@ -139,7 +138,7 @@ def hhbtag(
     flat_np_view(all_scores, axis=1)[ak.flatten(jet_mask[jet_sorting_indices] & event_mask, axis=1)] = flat_np_view(scores)  # noqa: E501
 
     # bring the scores back to the original ordering
-    all_scores = all_scores[back_transformation]
+    all_scores = all_scores[jet_unsorting_indices]
     events = set_ak_column(events, "hhbtag_score", all_scores)
 
     if self.config_inst.x.sync:

--- a/hbt/production/processes.py
+++ b/hbt/production/processes.py
@@ -12,8 +12,10 @@ import law
 import order
 
 from columnflow.production import Producer
+from columnflow.production.cms.dy import gen_dilepton
 from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column, Route
+from columnflow.types import Callable
 
 from hbt.util import IF_DATASET_IS_DY_AMCATNLO, IF_DATASET_IS_DY_POWHEG, IF_DATASET_IS_W_LNU
 
@@ -25,31 +27,49 @@ maybe_import("scipy.sparse")
 
 logger = law.logger.get_logger(__name__)
 
+LepId = int
 NJetsRange = tuple[int, int]
 PtRange = tuple[float, float]
 MRange = tuple[int, int]
 
 
 class stitched_process_ids(Producer):
-    """General class to calculate process ids for stitched samples.
+    """
+    General class to calculate process ids for stitched samples.
 
     Individual producers should derive from this class and set the following attributes:
 
-    :param id_table: scipy lookup table mapping processes variables (using key_func) to process ids
-    :param key_func: function to generate keys for the lookup, receiving values of stitching columns
+    :param id_lut: scipy lookup table mapping processes variables (using compute_lut_index) to process ids
+    :param compute_lut_index: function to generate keys for the lookup, receiving values of stitching columns
     :param stitching_columns: list of observables to use for stitching
     :param cross_check_translation_dict: dictionary to translate stitching columns to auxiliary
         fields of process objects, used for cross checking the validity of obtained ranges
     :param include_condition: condition for including stitching columns in used columns
     """
 
+    recovery_thresholds = {}
+
     @abc.abstractproperty
-    def id_table(self) -> sp.sparse._lil.lil_matrix:
+    def stitching_columns(self) -> list[str | Route]:
+        # must be overwritten by inheriting classes
+        ...
+
+    @property
+    def uses_for_stitching(self) -> set[str | Route]:
+        return self.stitching_columns
+
+    @abc.abstractproperty
+    def include_condition(self) -> Callable | None:
+        # must be overwritten by inheriting classes
+        ...
+
+    @abc.abstractproperty
+    def id_lut(self) -> sp.sparse._lil.lil_matrix:
         # must be overwritten by inheriting classes
         ...
 
     @abc.abstractmethod
-    def key_func(self, *values: ak.Array) -> int:
+    def compute_lut_index(self, *values: ak.Array) -> int:
         # must be overwritten by inheriting classes
         ...
 
@@ -61,7 +81,8 @@ class stitched_process_ids(Producer):
     def init_func(self, **kwargs) -> None:
         # if there is a include_condition set, apply it to both used and produced columns
         cond = lambda args: {self.include_condition(*args)} if self.include_condition else {*args}
-        self.uses |= cond(self.stitching_columns or [])  # TODO: breaks for us
+        if (load := self.uses_for_stitching):
+            self.uses |= cond(load)
         self.produces |= cond(["process_id"])
 
     def call_func(self, events: ak.Array, **kwargs) -> ak.Array:
@@ -81,15 +102,27 @@ class stitched_process_ids(Producer):
         stitching_values = [Route(obs).apply(events) for obs in self.stitching_columns]
 
         # run the cross check function if defined
-        if callable(self.stitching_range_cross_check):
-            self.stitching_range_cross_check(process_inst, stitching_values)
+        if callable(self.stitching_values_cross_check):
+            self.stitching_values_cross_check(process_inst, stitching_values)
 
         # lookup the id and check for invalid values
-        process_ids = np.squeeze(np.asarray(self.id_table[self.key_func(*stitching_values)].todense()))
+        process_ids = np.squeeze(np.asarray(self.id_lut[self.compute_lut_index(*stitching_values), 0].todense()))
         invalid_mask = process_ids == 0
         if ak.any(invalid_mask):
+            raise ValueError(f"found {sum(invalid_mask)} events that could not be assigned to a process")
+
+        # when the assigned process ids contain the id of the main process of the dataset, it should be the only
+        # identified process and there should be none other, as this would be logically inconsistent
+        unique_ids = set(np.unique(process_ids))
+        if process_inst.id in unique_ids and len(unique_ids) > 1:
+            other_process_names = [
+                self.config_inst.get_process(pid).name
+                for pid in unique_ids - {process_inst.id}
+            ]
             raise ValueError(
-                f"found {sum(invalid_mask)} events that could not be assigned to a process",
+                f"dataset '{self.dataset_inst.name}' contains events that are assigned the main process "
+                f"'{process_inst.name}' but also other processes '{','.join(other_process_names)}' which is "
+                "logically inconsistent",
             )
 
         # store them
@@ -97,7 +130,7 @@ class stitched_process_ids(Producer):
 
         return events
 
-    def stitching_range_cross_check(
+    def stitching_values_cross_check(
         self,
         process_inst: order.Process,
         stitching_values: list[ak.Array],
@@ -105,38 +138,80 @@ class stitched_process_ids(Producer):
         # define lookup for stitching observable -> process auxiliary values to compare with
         # raise a warning if a datasets was already created for a specific "bin" (leaf process),
         # but actually does not fit
-        for column, values in zip(self.stitching_columns, stitching_values):
+        for i, (column, values) in enumerate(zip(self.stitching_columns, stitching_values)):
             aux_name = self.cross_check_translation_dict[str(column)]
-            if not process_inst.has_aux(aux_name):
+            if (aux_val := process_inst.x(aux_name, None)) is None:
                 continue
-            aux_min, aux_max = process_inst.x(aux_name)
-            outliers = (values < aux_min) | (values >= aux_max)
-            if ak.any(outliers):
-                logger.warning(
-                    f"dataset {self.dataset_inst.name} is meant to contain {aux_name} values in "
-                    f"the range [{aux_min}, {aux_max}), but found {ak.sum(outliers)} events "
-                    "outside this range",
+            if isinstance(aux_val, (int, float)):
+                unmatched = values != aux_val
+                if ak.any(unmatched):
+                    logger.warning(
+                        f"dataset {self.dataset_inst.name} is meant to contain {aux_name} values of "
+                        f"{aux_val}, but found {ak.sum(unmatched)} events with different values",
+                    )
+            elif isinstance(aux_val, (list, tuple)) and len(aux_val) == 2:
+                aux_min, aux_max = aux_val
+                min_outlier = values < aux_min
+                max_outlier = values >= aux_max
+                outliers = min_outlier | max_outlier
+                if ak.any(outliers):
+                    # exception or warning
+                    msg = (
+                        f"dataset {self.dataset_inst.name} is meant to contain {aux_name} values in the range "
+                        f"[{aux_min}, {aux_max}), but found {ak.sum(outliers)} events outside this range"
+                    )
+                    if (recovery_threshold := self.recovery_thresholds.get(aux_name)) is None:
+                        raise ValueError(msg)
+                    else:
+                        logger.warning(f"{msg}, trying to recover with treshold of {recovery_threshold}")
+                    # cap values if they are within an acceptable range
+                    if ak.any(min_outlier):
+                        recover_mask = (aux_min - values[min_outlier]) <= recovery_threshold
+                        # in case not all outliers can be recovered, do not deal with these cases but raise an error
+                        if not ak.all(recover_mask):
+                            raise ValueError(
+                                f"dataset {self.dataset_inst.name} has {ak.sum(min_outlier)} events "
+                                "with values below the minimum, but not all of them can be recovered",
+                            )
+                        stitching_values[i] = ak.where(min_outlier, aux_min, values)
+                    if ak.any(max_outlier):
+                        recover_mask = (values[max_outlier] - aux_max) <= recovery_threshold
+                        # in case not all outliers can be recovered, do not deal with these cases but raise an error
+                        if not ak.all(recover_mask):
+                            raise ValueError(
+                                f"dataset {self.dataset_inst.name} has {ak.sum(max_outlier)} events "
+                                "with values below the maximum, but not all of them can be recovered",
+                            )
+                        stitching_values[i] = ak.where(max_outlier, aux_max - 1e-5, values)
+            else:
+                raise TypeError(
+                    f"auxiliary value {aux_name} of process {process_inst.name} has unexpected type "
+                    f"{type(aux_val).__name__}, no stitching value cross check can be performed",
                 )
 
 
-class stiched_process_ids_nj_pt(stitched_process_ids):
+class stitched_process_ids_nj_pt(stitched_process_ids):
     """
     Process identifier for subprocesses spanned by a jet multiplicity and an optional pt range, such
     as DY or W->lnu, which have (e.g.) "*_1j" as well as "*_1j_pt100to200" subprocesses.
     """
 
     # id table is set during setup, create a non-abstract class member in the meantime
-    id_table = None
+    id_lut = None
 
     # required aux fields
     njets_aux = "njets"
     pt_aux = "ptll"
 
+    recovery_thresholds = {
+        "ptll": 1.0,
+    }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # setup during setup
-        self.sorted_stitching_ranges: list[tuple[NJetsRange, list[PtRange]]]
+        # filled during setup
+        self.stitching_ranges: list[tuple[NJetsRange, PtRange]] = []
 
         # check that aux fields are present in cross_check_translation_dict
         for field in (self.njets_aux, self.pt_aux):
@@ -149,35 +224,28 @@ class stiched_process_ids_nj_pt(stitched_process_ids):
         ...
 
     def setup_func(self, task: law.Task, **kwargs) -> None:
-        # define stitching ranges for the DY datasets covered by this producer's dy_inclusive_dataset
-        stitching_ranges: dict[NJetsRange, list[PtRange]] = {}
+        # fill stitching ranges
         for proc in self.leaf_processes:
-            njets = proc.x(self.njets_aux)
-            stitching_ranges.setdefault(njets, [])
-            if proc.has_aux(self.pt_aux):
-                stitching_ranges[njets].append(proc.x(self.pt_aux))
+            njets = proc.x(self.njets_aux, (0, np.inf))
+            pt = proc.x(self.pt_aux, (0.0, np.inf))
+            self.stitching_ranges.append((njets, pt))
 
-        # sort by the first element of the ptll range
-        self.sorted_stitching_ranges = [
-            (nj_range, sorted(stitching_ranges[nj_range], key=lambda ptll_range: ptll_range[0]))
-            for nj_range in sorted(stitching_ranges.keys(), key=lambda nj_range: nj_range[0])
-        ]
+        # make unique and sort
+        self.stitching_ranges = sorted(set(self.stitching_ranges))
 
         # define the lookup table
-        max_nj_bin = len(self.sorted_stitching_ranges)
-        max_pt_bin = max(map(len, stitching_ranges.values()))
-        self.id_table = sp.sparse.lil_matrix((max_nj_bin + 1, max_pt_bin + 1), dtype=np.int64)
+        self.id_lut = sp.sparse.lil_matrix((len(self.stitching_ranges), 1), dtype=np.int64)
 
         # fill it
         for proc in self.leaf_processes:
-            key = self.key_func(proc.x(self.njets_aux)[0], proc.x(self.pt_aux, [-1])[0])
-            self.id_table[key] = proc.id
+            index = self.compute_lut_index(proc.x(self.njets_aux, [0])[0], proc.x(self.pt_aux, [0])[0])
+            self.id_lut[index, 0] = proc.id
 
-    def key_func(
+    def compute_lut_index(
         self,
         njets: int | np.ndarray,
         pt: int | float | np.ndarray,
-    ) -> tuple[int, int] | tuple[np.ndarray, np.ndarray]:
+    ) -> int | np.ndarray:
         # potentially convert single values into arrays
         single = False
         if isinstance(njets, int):
@@ -186,31 +254,133 @@ class stiched_process_ids_nj_pt(stitched_process_ids):
             pt = np.array([pt], dtype=np.float32)
             single = True
 
-        # map into bins (index 0 means no binning)
-        nj_bins = np.zeros(len(njets), dtype=np.int32)
-        pt_bins = np.zeros(len(pt), dtype=np.int32)
-        for nj_bin, (nj_range, pt_ranges) in enumerate(self.sorted_stitching_ranges, 1):
-            # nj_bin
+        # map into bins (-1 means no binning and should raise errors)
+        indices = -np.ones(len(njets), dtype=np.int32)
+        for index, (nj_range, pt_range) in enumerate(self.stitching_ranges):
             nj_mask = (nj_range[0] <= njets) & (njets < nj_range[1])
-            nj_bins[nj_mask] = nj_bin
-            # pt_bin
-            for pt_bin, (pt_min, pt_max) in enumerate(pt_ranges, 1):
-                pt_mask = (pt_min <= pt) & (pt < pt_max)
-                pt_bins[nj_mask & pt_mask] = pt_bin
+            pt_mask = (pt_range[0] <= pt) & (pt < pt_range[1])
+            mask = nj_mask & pt_mask
+            if np.any(indices[mask] != -1):
+                raise RuntimeError(
+                    f"found misconfigured leaf process definitions while assigning process ids with {self.cls_name} "
+                    f"producer in dataset {self.dataset_inst.name} (hint: check 'stitching_ranges')",
+                )
+            indices[mask] = index
 
-        return (nj_bins[0], pt_bins[0]) if single else (nj_bins, pt_bins)
+        return indices[0] if single else indices
 
 
-class stiched_process_ids_m(stitched_process_ids):
+class stitched_process_ids_lep_nj_pt(stitched_process_ids):
+    """
+    Same as :py:class:`stitched_process_ids_nj_pt`, but with an additional generator-level lepton pair identification.
+    """
+
+    # id table is set during setup, create a non-abstract class member in the meantime
+    id_lut = None
+
+    # required aux fields
+    lep_aux = "lep_id"
+    njets_aux = "njets"
+    pt_aux = "ptll"
+
+    recovery_thresholds = {
+        "ptll": 1.0,
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # filled during setup
+        self.stitching_ranges: list[tuple[LepId, NJetsRange, PtRange]] = []
+
+        # check that aux fields are present in cross_check_translation_dict
+        for field in (self.lep_aux, self.njets_aux, self.pt_aux):
+            if field not in self.cross_check_translation_dict.values():
+                raise ValueError(f"field {field} must be present in cross_check_translation_dict")
+
+    @abc.abstractproperty
+    def leaf_processes(self) -> list[order.Process]:
+        # must be overwritten by inheriting classes
+        ...
+
+    def init_func(self, **kwargs) -> None:
+        super().init_func(**kwargs)
+        self.uses.add(gen_dilepton)
+
+    def call_func(self, events: ak.Array, **kwargs) -> ak.Array:
+        events = self[gen_dilepton](events, **kwargs)
+        return super().call_func(events, **kwargs)
+
+    def setup_func(self, task: law.Task, **kwargs) -> None:
+        # fill stitching ranges
+        for proc in self.leaf_processes:
+            lep = proc.x(self.lep_aux, 0)
+            njets = proc.x(self.njets_aux, (0, np.inf))
+            pt = proc.x(self.pt_aux, (0.0, np.inf))
+            self.stitching_ranges.append((lep, njets, pt))
+
+        # make unique and sort
+        self.stitching_ranges = sorted(set(self.stitching_ranges))
+
+        # define the lookup table
+        self.id_lut = sp.sparse.lil_matrix((len(self.stitching_ranges), 1), dtype=np.int64)
+
+        # fill it
+        for proc in self.leaf_processes:
+            index = self.compute_lut_index(
+                proc.x(self.lep_aux, 0),
+                proc.x(self.njets_aux, [0])[0],
+                proc.x(self.pt_aux, [0])[0],
+            )
+            self.id_lut[index, 0] = proc.id
+
+    def compute_lut_index(
+        self,
+        lep: int | np.ndarray,
+        njets: int | np.ndarray,
+        pt: int | float | np.ndarray,
+    ) -> int | np.ndarray:
+        # potentially convert single values into arrays
+        single = False
+        if isinstance(njets, int):
+            assert isinstance(lep, int)
+            assert isinstance(pt, (int, float))
+            lep = np.array([lep], dtype=np.int32)
+            njets = np.array([njets], dtype=np.int32)
+            pt = np.array([pt], dtype=np.float32)
+            single = True
+
+        # map into bins (-1 means no binning and should raise errors)
+        indices = -np.ones(len(njets), dtype=np.int32)
+        for index, (_lep, nj_range, pt_range) in enumerate(self.stitching_ranges):
+            lep_mask = (_lep == 0) | (_lep == lep)
+            nj_mask = (nj_range[0] <= njets) & (njets < nj_range[1])
+            pt_mask = (pt_range[0] <= pt) & (pt < pt_range[1])
+            mask = lep_mask & nj_mask & pt_mask
+            if np.any(indices[mask] != -1):
+                raise RuntimeError(
+                    f"found misconfigured leaf process definitions while assigning process ids with {self.cls_name} "
+                    f"producer in dataset {self.dataset_inst.name} (hint: check 'stitching_ranges')",
+                )
+            indices[mask] = index
+
+        return indices[0] if single else indices
+
+
+class stitched_process_ids_m(stitched_process_ids):
     """
     Process identifier for subprocesses spanned by the mll mass.
     """
 
     # id table is set during setup, create a non-abstract class member in the meantime
-    id_table = None
+    id_lut = None
 
     # required aux fields
     var_aux = "mll"
+
+    recovery_thresholds = {
+        "mll": 1.0,
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -246,14 +416,14 @@ class stiched_process_ids_m(stitched_process_ids):
 
         # define the lookup table
         max_var_bin = len(self.sorted_stitching_ranges)
-        self.id_table = sp.sparse.lil_matrix((max_var_bin + 1, 1), dtype=np.int64)
+        self.id_lut = sp.sparse.lil_matrix((max_var_bin + 1, 1), dtype=np.int64)
 
         # fill it
         for proc in self.leaf_processes:
-            key = self.key_func(proc.x(self.var_aux)[0])
-            self.id_table[key] = proc.id
+            key = self.compute_lut_index(proc.x(self.var_aux)[0])
+            self.id_lut[key] = proc.id
 
-    def key_func(
+    def compute_lut_index(
         self,
         mll: int | float | np.ndarray,
     ) -> tuple[int] | tuple[np.ndarray]:
@@ -282,62 +452,30 @@ class stiched_process_ids_m(stitched_process_ids):
 
         return super().call_func(events, **kwargs)
 
-    def stitching_range_cross_check(
-        self,
-        process_inst: order.Process,
-        stitching_values: list[ak.Array],
-    ) -> None:
-        # TODO: this is a copy of the code above (with outlier recovery), we could factorize this a bit :)
-        for i, (column, values) in enumerate(zip(self.stitching_columns, stitching_values)):
-            aux_name = self.cross_check_translation_dict[str(column)]
-            if not process_inst.has_aux(aux_name):
-                continue
-            aux_min, aux_max = process_inst.x(aux_name)
-            min_outlier = values < aux_min
-            max_outlier = values >= aux_max
-            outliers = min_outlier | max_outlier
-            if ak.any(outliers):
-                logger.warning(
-                    f"dataset {self.dataset_inst.name} is meant to contain {aux_name} values in "
-                    f"the range [{aux_min}, {aux_max}), but found {ak.sum(outliers)} events "
-                    "outside this range",
-                )
-                # cap values if they are within an acceptable range
-                if ak.any(min_outlier):
-                    recover_mask = (aux_min - values[min_outlier]) < 1.0
-                    # in case not all outliers can be recovered, do not deal with these cases but raise an error
-                    if not ak.all(recover_mask):
-                        raise ValueError(
-                            f"dataset {self.dataset_inst.name} has {ak.sum(min_outlier)} events "
-                            "with values below the minimum, but not all of them can be recovered",
-                        )
-                    stitching_values[i] = ak.where(min_outlier, aux_min, values)
-                if ak.any(max_outlier):
-                    recover_mask = (values[max_outlier] - aux_max) < 1.0
-                    # in case not all outliers can be recovered, do not deal with these cases but raise an error
-                    if not ak.all(recover_mask):
-                        raise ValueError(
-                            f"dataset {self.dataset_inst.name} has {ak.sum(max_outlier)} events "
-                            "with values below the maximum, but not all of them can be recovered",
-                        )
-                    stitching_values[i] = ak.where(max_outlier, aux_max - 1e-5, values)
 
-
-process_ids_dy_amcatnlo = stiched_process_ids_nj_pt.derive("process_ids_dy_amcatnlo", cls_dict={
+process_ids_dy_amcatnlo = stitched_process_ids_nj_pt.derive("process_ids_dy_amcatnlo", cls_dict={
     "stitching_columns": ["LHE.NpNLO", "LHE.Vpt"],
     "cross_check_translation_dict": {"LHE.NpNLO": "njets", "LHE.Vpt": "ptll"},
     "include_condition": IF_DATASET_IS_DY_AMCATNLO,
     # still misses leaf_processes, must be set dynamically
 })
 
-process_ids_dy_powheg = stiched_process_ids_m.derive("process_ids_dy_powheg", cls_dict={
+process_ids_dy_lep_amcatnlo = stitched_process_ids_lep_nj_pt.derive("process_ids_dy_lep_amcatnlo", cls_dict={
+    "stitching_columns": ["gen_dilepton_pdgid", "LHE.NpNLO", "LHE.Vpt"],
+    "uses_for_stitching": ["LHE.NpNLO", "LHE.Vpt"],  # gen_dilepton_pdgid must haven been produced dynamically
+    "cross_check_translation_dict": {"gen_dilepton_pdgid": "lep_id", "LHE.NpNLO": "njets", "LHE.Vpt": "ptll"},
+    "include_condition": IF_DATASET_IS_DY_AMCATNLO,
+    # still misses leaf_processes, must be set dynamically
+})
+
+process_ids_dy_powheg = stitched_process_ids_m.derive("process_ids_dy_powheg", cls_dict={
     "stitching_columns": ["LHEmll"],
     "cross_check_translation_dict": {"LHEmll": "mll"},
     "include_condition": IF_DATASET_IS_DY_POWHEG,
     # still misses leaf_processes, must be set dynamically
 })
 
-process_ids_w_lnu = stiched_process_ids_nj_pt.derive("process_ids_w_lnu", cls_dict={
+process_ids_w_lnu = stitched_process_ids_nj_pt.derive("process_ids_w_lnu", cls_dict={
     "stitching_columns": ["LHE.NpNLO", "LHE.Vpt"],
     "cross_check_translation_dict": {"LHE.NpNLO": "njets", "LHE.Vpt": "ptll"},
     "include_condition": IF_DATASET_IS_W_LNU,

--- a/hbt/selection/default.py
+++ b/hbt/selection/default.py
@@ -451,6 +451,9 @@ def increment_stats(
     keys_for_stats = []
     keys_for_hists = []
 
+    # helper to cast to float64
+    f64 = lambda a: ak.values_astype(a, np.float64)
+
     def add(key, sel, weight=None, for_stats=False, for_hists=True):
         stats_map[key] = sel if weight is None else (weight, sel)
         if for_stats and key not in keys_for_stats:
@@ -517,7 +520,7 @@ def increment_stats(
         if "sum_mc_weight_per_process" not in stats:
             stats["sum_mc_weight_per_process"] = defaultdict(float)
         for proc_id in np.unique(events.process_id):
-            proc_weights = events.mc_weight[events.process_id == proc_id]
+            proc_weights = f64(events.mc_weight[events.process_id == proc_id])
             stats["num_events_per_process"][str(proc_id)] += float(len(proc_weights))
             stats["sum_mc_weight_per_process"][str(proc_id)] += float(ak.sum(proc_weights))
 
@@ -540,6 +543,6 @@ def increment_stats(
             fill_hist(hists[key], fill_data, last_edge_inclusive=True)
 
         if key in keys_for_stats:
-            stats[key] += float(ak.sum(sel if is_num else weight[sel]))
+            stats[key] += float(ak.sum(f64(sel if is_num else weight[sel])))
 
     return events, results

--- a/hbt/util.py
+++ b/hbt/util.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 __all__ = []
 
+import functools
+
 from columnflow.types import Any
 from columnflow.columnar_util import ArrayFunction, deferred_column
 from columnflow.util import maybe_import
@@ -66,68 +68,27 @@ def IF_RUN_3_2022(self: ArrayFunction.DeferredColumn, func: ArrayFunction) -> An
     return self.get() if (func.config_inst.campaign.x.run == 3 and func.config_inst.campaign.x.year == 2022) else None
 
 
-@deferred_column
-def IF_DATASET_HAS_LHE_WEIGHTS(
-    self: ArrayFunction.DeferredColumn,
-    func: ArrayFunction,
-) -> Any | set[Any]:
-    return self.get() if not func.dataset_inst.has_tag("no_lhe_weights") else None
+def IF_DATASET_HAS_TAG(*args, negate: bool = False, **kwargs) -> ArrayFunction.DeferredColumn:
+    @deferred_column
+    def deferred(
+        self: ArrayFunction.DeferredColumn,
+        func: ArrayFunction,
+    ) -> Any | set[Any]:
+        return self.get() if func.dataset_inst.has_tag(*args, **kwargs) is not negate else None
+
+    return deferred
 
 
-@deferred_column
-def IF_DATASET_HAS_TOP(
-    self: ArrayFunction.DeferredColumn,
-    func: ArrayFunction,
-) -> Any | set[Any]:
-    return self.get() if func.dataset_inst.has_tag("has_top") else None
+IF_DATASET_NOT_HAS_TAG = functools.partial(IF_DATASET_HAS_TAG, negate=True)
 
-
-@deferred_column
-def IF_DATASET_IS_TT(
-    self: ArrayFunction.DeferredColumn,
-    func: ArrayFunction,
-) -> Any | set[Any]:
-    return self.get() if func.dataset_inst.has_tag("ttbar") else None
-
-
-@deferred_column
-def IF_DATASET_IS_DY(
-    self: ArrayFunction.DeferredColumn,
-    func: ArrayFunction,
-) -> Any | set[Any]:
-    return self.get() if func.dataset_inst.has_tag("dy") else None
-
-
-@deferred_column
-def IF_DATASET_IS_DY_MADGRAPH(
-    self: ArrayFunction.DeferredColumn,
-    func: ArrayFunction,
-) -> Any | set[Any]:
-    return self.get() if func.dataset_inst.has_tag("dy_madgraph") else None
-
-
-@deferred_column
-def IF_DATASET_IS_DY_AMCATNLO(
-    self: ArrayFunction.DeferredColumn,
-    func: ArrayFunction,
-) -> Any | set[Any]:
-    return self.get() if func.dataset_inst.has_tag("dy_amcatnlo") else None
-
-
-@deferred_column
-def IF_DATASET_IS_DY_POWHEG(
-    self: ArrayFunction.DeferredColumn,
-    func: ArrayFunction,
-) -> Any | set[Any]:
-    return self.get() if func.dataset_inst.has_tag("dy_powheg") else None
-
-
-@deferred_column
-def IF_DATASET_IS_W_LNU(
-    self: ArrayFunction.DeferredColumn,
-    func: ArrayFunction,
-) -> Any | set[Any]:
-    return self.get() if func.dataset_inst.has_tag("w_lnu") else None
+IF_DATASET_HAS_LHE_WEIGHTS = IF_DATASET_NOT_HAS_TAG("no_lhe_weights")
+IF_DATASET_HAS_TOP = IF_DATASET_HAS_TAG("has_top")
+IF_DATASET_IS_TT = IF_DATASET_HAS_TAG("ttbar")
+IF_DATASET_IS_DY = IF_DATASET_HAS_TAG("dy")
+IF_DATASET_IS_DY_MADGRAPH = IF_DATASET_HAS_TAG("dy_madgraph")
+IF_DATASET_IS_DY_AMCATNLO = IF_DATASET_HAS_TAG("dy_amcatnlo")
+IF_DATASET_IS_DY_POWHEG = IF_DATASET_HAS_TAG("dy_powheg")
+IF_DATASET_IS_W_LNU = IF_DATASET_HAS_TAG("w_lnu")
 
 
 @deferred_column

--- a/law.cfg
+++ b/law.cfg
@@ -38,6 +38,12 @@ job_file_dir_mkdtemp: sub_{{task_id}}_XXX
 crab_sandbox_name: CMSSW_14_2_1::arch=el9_amd64_gcc12
 
 
+[target]
+
+# when removing target collections, use multi-threading
+collection_remove_threads: 2
+
+
 #
 # analysis specific settings
 #

--- a/law_outputs.cfg
+++ b/law_outputs.cfg
@@ -88,13 +88,18 @@ task_cf.CreateSyncFile: local
 
 [versions]
 
+# rerun with met phi correction https://github.com/columnflow/columnflow/pull/719
+# and a fixed (sub) process id assignment in stitched datasets ADD-LINK (30.7.2025)
+cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}: prod13
+cfg_{22,23}{pre,post}_v14__task_cf.CalibrateEvents: prod13
+
 # rerun with fixed isolation cut on first tau https://github.com/uhh-cms/hh2bbtautau/pull/82
 # and the switch to custom jet lepton cleaning https://github.com/uhh-cms/hh2bbtautau/pull/83 (17.7.2025)
-cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}: prod12
+# cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}: prod12
 
 # rerun with updated calibration without TEC-to-MET propagation (27.6.2025)
 # cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}: prod11
-cfg_{22,23}{pre,post}_v14__task_cf.CalibrateEvents: prod11
+# cfg_{22,23}{pre,post}_v14__task_cf.CalibrateEvents: prod11
 
 # added ecal crack rejection to electron selection (23.6.2025)
 # cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}: prod10

--- a/law_outputs.cfg
+++ b/law_outputs.cfg
@@ -88,10 +88,13 @@ task_cf.CreateSyncFile: local
 
 [versions]
 
+# rerun with fixed jet sorting for hhbtag score https://github.com/uhh-cms/hh2bbtautau/pull/87 (11.8.2025)
+cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}: prod14
+
 # rerun with met phi correction https://github.com/columnflow/columnflow/pull/719
 # and a fixed (sub) process id assignment in stitched datasets ADD-LINK (30.7.2025)
-cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}__dataset_dy_*: prod13_newstitching
-cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}: prod13
+# cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}__dataset_dy_*: prod13_newstitching
+# cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}: prod13
 cfg_{22,23}{pre,post}_v14__task_cf.CalibrateEvents: prod13
 
 # rerun with fixed isolation cut on first tau https://github.com/uhh-cms/hh2bbtautau/pull/82

--- a/law_outputs.cfg
+++ b/law_outputs.cfg
@@ -90,6 +90,7 @@ task_cf.CreateSyncFile: local
 
 # rerun with met phi correction https://github.com/columnflow/columnflow/pull/719
 # and a fixed (sub) process id assignment in stitched datasets ADD-LINK (30.7.2025)
+cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}__dataset_dy_*: prod13_newstitching
 cfg_{22,23}{pre,post}_v14__task_cf.{SelectEvents,MergeSelectionStats,ReduceEvents,MergeReductionStats,ProvideReducedEvents}: prod13
 cfg_{22,23}{pre,post}_v14__task_cf.CalibrateEvents: prod13
 


### PR DESCRIPTION
### Changes to datasets

- Removed DY 4to10 and 10to50 datasets due to the pythia bug. They will not be reproduced. (they had virtually no contribution anyways)
- Added additional `dy_tautau_m50toinf_{0,1,2}j_amcatnlo` samples. They are not yet existing for all campaigns and will be completed this week.
- So-called "filtered" samples were also added but commented out for now. They contain even more statistics but in a very specific phase space and require another level of stitching that will be done soon.

### Changed selection and norm weight production

- Datasets in which tautau events are to be removed are tagged as `dy_drop_tautau`. The default selection picks this up and optionally discards those events as a normal selector. The selector step is `mc_filter` and can also be used for more generic filtering in the future. In particular, events are not dropped as if they never existed in the first place. Instead, by going through a normal selection step, event summaries (`sum_event_weight[_per_process]`, `num_events[_per_process]`, ...) are kept, allowing for still using the event info (not the broken, kinematic variables) for the stitching.
- The DY process indexer is adapted to distinguish subprocesses in terms of mll, additional jets, *and now* the leptonic decay.
- We use an extended stitching weight producer now. The only difference to the cf-central producer is that in the event summaries (as per `MergeSelectionStats`), the sum of weights and number of events for true tautau processes is set to zero for the computation of the overall sum of weights (denominator of the weight formula). Effectively, this is equal to treating those events as "never existed". In the numerator though, for the calculation of the (sub)process cross section, the statistics are kept to increase the BR precision.

### Additional config changes

- Smaller improvements along the way, nothing critical
- Updated versions in the outputs config