### PR TITLE
modify vbfjtagger release

### DIFF
--- a/hbt/production/vbfjtag.py
+++ b/hbt/production/vbfjtag.py
@@ -55,7 +55,7 @@ def vbfjtag(
     )
 
     # ordering by decreasing eta then pt
-    f = 10**(np.ceil(np.log10(ak.max(events.Jet.pt))) + 2)
+    f = 10**(np.ceil(np.log10(ak.max(events.Jet.pt) or 0.0)) + 2)
     jet_sorting_key = abs(events.Jet.eta) * f + events.Jet.pt
     jet_sorting_indices = ak.argsort(jet_sorting_key, axis=-1, ascending=False)
 


### PR DESCRIPTION
change to v1.1, the sorting went from eta to abs(eta) (private discussion with elvira), the documentation for this is currently not updated

TODO: test it, need to go to lxplus for that due to current gitlab issue